### PR TITLE
Fix for UnicodeDecodeError on Macbook

### DIFF
--- a/app.py
+++ b/app.py
@@ -349,4 +349,11 @@ def main() -> None:
     print("Press Ctrl+C to stop")
     print()
 
-    app.run(host=args.host, port=args.port, debug=args.debug, threaded=True)
+# Avoid loading a global ~/.env when running the script directly.
+    app.run(
+        host=args.host,
+        port=args.port,
+        debug=args.debug,
+        threaded=True,
+        load_dotenv=False,
+    )


### PR DESCRIPTION
On first install using a MacBook M1 Max running Tahoe 26.3, after installing all dependencies through brew, I got this error when running `sudo python3 intercept.py`

```
Traceback (most recent call last):
  File "/Users/unipheas/Developer/intercept/intercept.py", line 28, in <module>
    main()
  File "/Users/unipheas/Developer/intercept/app.py", line 352, in main
    app.run(host=args.host, port=args.port, debug=args.debug, threaded=True)
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/site-packages/flask/app.py", line 624, in run
    cli.load_dotenv()
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/site-packages/flask/cli.py", line 760, in load_dotenv
    data |= dotenv.dotenv_values(default_path, encoding="utf-8")
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/site-packages/dotenv/main.py", line 393, in dotenv_values
    return DotEnv(
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/site-packages/dotenv/main.py", line 76, in dict
    resolve_variables(raw_values, override=self.override)
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/site-packages/dotenv/main.py", line 239, in resolve_variables
    for name, value in values:
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/site-packages/dotenv/main.py", line 85, in parse
    for mapping in with_warn_for_invalid_lines(parse_stream(stream)):
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/site-packages/dotenv/main.py", line 25, in with_warn_for_invalid_lines
    for mapping in mappings:
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/site-packages/dotenv/parser.py", line 173, in parse_stream
    reader = Reader(stream)
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/site-packages/dotenv/parser.py", line 64, in __init__
    self.string = stream.read()
  File "/Users/unipheas/.pyenv/versions/3.9.19/lib/python3.9/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbb in position 0: invalid start byte
```

This PR is adding `load_dotenv=False` to app.run to resolve UnicodeDecodeError