### PR TITLE
Fix Docker startup failure caused by ./data bind mount shadowing app package

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,9 @@ services:
     # USB device mapping (alternative to privileged mode)
     # devices:
     #   - /dev/bus/usb:/dev/bus/usb
-    volumes:
+    # volumes:
       # Persist data directory
-      - ./data:/app/data
+      # - ./data:/app/data
       # Optional: mount logs directory
       # - ./logs:/app/logs
     environment:


### PR DESCRIPTION
This PR fixes a Docker startup issue where the ./data bind mount overwrote
/app/data inside the container, causing:

    ModuleNotFoundError: No module named 'data.oui'

Because the application imports `data.oui`, mounting ./data masks the
package and breaks startup.

Fix:
- Remove/comment out the ./data bind mount in docker-compose.yml

The application starts correctly without the mount, and database/data
files continue to be created under /app/instance as expected.

Tested with:
- Fresh docker-compose build
- Clean container startup

# NOTE: Mounting ./data here breaks imports by shadowing /app/data (Python package)
# Do not bind mount this directory

