### PR TITLE
Add Soapy Airspy package and airspy pages to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     soapysdr-module-rtlsdr \
     soapysdr-module-hackrf \
     soapysdr-module-lms7 \
+    soapysdr-module-airspy \
+    airspy \
     limesuite \
     hackrf \
     # Utilities


### PR DESCRIPTION
This PR adds the Airspy packages to the Docker build. I have tested this in my setup, and my AirSpy now shows up in the UI and is usable.