### PR TITLE
feat: add OOK/AM envelope detection mode to Morse decoder

### DIFF
--- a/static/js/modes/morse.js
+++ b/static/js/modes/morse.js
@@ -103,6 +103,7 @@ var MorseMode = (function () {
             device: (el('deviceSelect') && el('deviceSelect').value) || '0',
             sdr_type: (el('sdrTypeSelect') && el('sdrTypeSelect').value) || 'rtlsdr',
             bias_t: (typeof getBiasTEnabled === 'function') ? getBiasTEnabled() : false,
+            detect_mode: (el('morseDetectMode') && el('morseDetectMode').value) || 'goertzel',
             tone_freq: (el('morseToneFreq') && el('morseToneFreq').value) || '700',
             bandwidth_hz: (el('morseBandwidth') && el('morseBandwidth').value) || '200',
             auto_tone_track: !!(el('morseAutoToneTrack') && el('morseAutoToneTrack').checked),
@@ -124,6 +125,7 @@ var MorseMode = (function () {
                 frequency: (el('morseFrequency') && el('morseFrequency').value) || '14.060',
                 gain: (el('morseGain') && el('morseGain').value) || '40',
                 ppm: (el('morsePPM') && el('morsePPM').value) || '0',
+                detect_mode: (el('morseDetectMode') && el('morseDetectMode').value) || 'goertzel',
                 tone_freq: (el('morseToneFreq') && el('morseToneFreq').value) || '700',
                 bandwidth_hz: (el('morseBandwidth') && el('morseBandwidth').value) || '200',
                 auto_tone_track: !!(el('morseAutoToneTrack') && el('morseAutoToneTrack').checked),
@@ -167,6 +169,9 @@ var MorseMode = (function () {
         if (el('morseShowRaw') && settings.show_raw !== undefined) el('morseShowRaw').checked = !!settings.show_raw;
         if (el('morseShowDiag') && settings.show_diag !== undefined) el('morseShowDiag').checked = !!settings.show_diag;
 
+        if (settings.detect_mode) {
+            setDetectMode(settings.detect_mode);
+        }
         updateToneLabel((el('morseToneFreq') && el('morseToneFreq').value) || '700');
         updateWpmLabel((el('morseWpm') && el('morseWpm').value) || '15');
         onThresholdModeChange();
@@ -198,10 +203,11 @@ var MorseMode = (function () {
         state.controlsBound = true;
 
         var ids = [
-            'morseFrequency', 'morseGain', 'morsePPM', 'morseToneFreq', 'morseBandwidth',
-            'morseAutoToneTrack', 'morseToneLock', 'morseThresholdMode', 'morseManualThreshold',
-            'morseThresholdMultiplier', 'morseThresholdOffset', 'morseSignalGate',
-            'morseWpmMode', 'morseWpm', 'morseWpmLock', 'morseShowRaw', 'morseShowDiag'
+            'morseFrequency', 'morseGain', 'morsePPM', 'morseDetectMode', 'morseToneFreq',
+            'morseBandwidth', 'morseAutoToneTrack', 'morseToneLock', 'morseThresholdMode',
+            'morseManualThreshold', 'morseThresholdMultiplier', 'morseThresholdOffset',
+            'morseSignalGate', 'morseWpmMode', 'morseWpm', 'morseWpmLock',
+            'morseShowRaw', 'morseShowDiag'
         ];
 
         ids.forEach(function (id) {
@@ -1199,12 +1205,80 @@ var MorseMode = (function () {
         });
     }
 
+    function setDetectMode(mode) {
+        var hidden = el('morseDetectMode');
+        if (hidden) hidden.value = mode;
+
+        // Update toggle button styles
+        var btnGoertzel = el('morseDetectGoertzel');
+        var btnEnvelope = el('morseDetectEnvelope');
+        if (btnGoertzel && btnEnvelope) {
+            if (mode === 'envelope') {
+                btnEnvelope.style.background = 'var(--accent)';
+                btnEnvelope.style.color = '#000';
+                btnGoertzel.style.background = '';
+                btnGoertzel.style.color = '';
+            } else {
+                btnGoertzel.style.background = 'var(--accent)';
+                btnGoertzel.style.color = '#000';
+                btnEnvelope.style.background = '';
+                btnEnvelope.style.color = '';
+            }
+        }
+
+        // Toggle preset groups
+        var hfPresets = el('morseHFPresets');
+        var ismPresets = el('morseISMPresets');
+        if (hfPresets) hfPresets.style.display = mode === 'envelope' ? 'none' : 'flex';
+        if (ismPresets) ismPresets.style.display = mode === 'envelope' ? 'flex' : 'none';
+
+        // Toggle CW detector section (tone freq, bandwidth, tone track -- not needed for envelope)
+        var toneGroup = el('morseToneFreqGroup');
+        if (toneGroup) toneGroup.style.display = mode === 'envelope' ? 'none' : '';
+
+        // Toggle antenna notes
+        var hfNote = el('morseHFNote');
+        var envNote = el('morseEnvelopeNote');
+        if (hfNote) hfNote.style.display = mode === 'envelope' ? 'none' : '';
+        if (envNote) envNote.style.display = mode === 'envelope' ? '' : 'none';
+
+        // Update hint text
+        var hint = el('morseDetectHint');
+        if (hint) {
+            hint.textContent = mode === 'envelope'
+                ? 'OOK Envelope: AM demod, RMS detection. For ISM-band OOK/CW.'
+                : 'CW Tone: HF bands, USB demod, Goertzel filter. For amateur CW.';
+        }
+
+        // Set sensible default frequency when switching modes
+        var freqEl = el('morseFrequency');
+        if (freqEl) {
+            var curFreq = parseFloat(freqEl.value);
+            if (mode === 'envelope' && curFreq < 30) {
+                freqEl.value = '433.300';
+            } else if (mode === 'goertzel' && curFreq > 30) {
+                freqEl.value = '14.060';
+            }
+        }
+
+        // Set WPM default for envelope mode (OOK transmitters tend to be slower)
+        var wpmEl = el('morseWpm');
+        var wpmLabel = el('morseWpmLabel');
+        if (mode === 'envelope' && wpmEl) {
+            wpmEl.value = '12';
+            if (wpmLabel) wpmLabel.textContent = '12';
+        }
+
+        persistSettings();
+    }
+
     return {
         init: init,
         destroy: destroy,
         start: start,
         stop: stop,
         setFreq: setFreq,
+        setDetectMode: setDetectMode,
         exportTxt: exportTxt,
         exportCsv: exportCsv,
         copyToClipboard: copyToClipboard,

--- a/templates/partials/modes/morse.html
+++ b/templates/partials/modes/morse.html
@@ -3,21 +3,39 @@
     <div class="section">
         <h3>CW/Morse Decoder</h3>
         <p class="info-text morse-mode-help">
-            Decode CW (continuous wave) Morse with USB demod + Goertzel tone detection.
-            Start with 700 Hz tone and 200 Hz bandwidth.
+            Decode CW (continuous wave) Morse code. Supports HF amateur bands (USB + Goertzel tone
+            detection) and ISM/UHF OOK signals (AM + envelope detection).
         </p>
+    </div>
+
+    <div class="section">
+        <h3>Detection Mode</h3>
+        <div class="form-group">
+            <div style="display: flex; gap: 4px;">
+                <button class="preset-btn morseDetectBtn" id="morseDetectGoertzel"
+                        onclick="MorseMode.setDetectMode('goertzel')"
+                        style="flex: 1; background: var(--accent); color: #000;">CW Tone</button>
+                <button class="preset-btn morseDetectBtn" id="morseDetectEnvelope"
+                        onclick="MorseMode.setDetectMode('envelope')"
+                        style="flex: 1;">OOK Envelope</button>
+            </div>
+            <input type="hidden" id="morseDetectMode" value="goertzel">
+            <p id="morseDetectHint" class="info-text" style="font-size: 10px; color: var(--text-dim); margin-top: 4px;">
+                CW Tone: HF bands, USB demod, Goertzel filter. For amateur CW.
+            </p>
+        </div>
     </div>
 
     <div class="section">
         <h3>Frequency</h3>
         <div class="form-group">
             <label>Frequency (MHz)</label>
-            <input type="number" id="morseFrequency" value="14.060" step="0.001" min="0.5" max="30" placeholder="e.g., 14.060">
+            <input type="number" id="morseFrequency" value="14.060" step="0.001" min="0.5" max="1766" placeholder="e.g., 14.060">
             <span class="help-text morse-help-text">Enter CW center frequency in MHz (e.g., 7.030 for 40m).</span>
         </div>
         <div class="form-group">
             <label>Band Presets</label>
-            <div class="morse-presets">
+            <div class="morse-presets" id="morseHFPresets">
                 <button class="preset-btn" onclick="MorseMode.setFreq(3.560)">80m</button>
                 <button class="preset-btn" onclick="MorseMode.setFreq(7.030)">40m</button>
                 <button class="preset-btn" onclick="MorseMode.setFreq(10.116)">30m</button>
@@ -26,6 +44,13 @@
                 <button class="preset-btn" onclick="MorseMode.setFreq(21.060)">15m</button>
                 <button class="preset-btn" onclick="MorseMode.setFreq(24.910)">12m</button>
                 <button class="preset-btn" onclick="MorseMode.setFreq(28.060)">10m</button>
+            </div>
+            <div class="morse-presets" id="morseISMPresets" style="display: none; flex-wrap: wrap; gap: 4px;">
+                <button class="preset-btn" onclick="MorseMode.setFreq(315.000)">315</button>
+                <button class="preset-btn" onclick="MorseMode.setFreq(433.300)">433.3</button>
+                <button class="preset-btn" onclick="MorseMode.setFreq(433.920)">433.9</button>
+                <button class="preset-btn" onclick="MorseMode.setFreq(868.000)">868</button>
+                <button class="preset-btn" onclick="MorseMode.setFreq(915.000)">915</button>
             </div>
         </div>
     </div>
@@ -42,7 +67,7 @@
         </div>
     </div>
 
-    <div class="section">
+    <div class="section" id="morseToneFreqGroup">
         <h3>CW Detector</h3>
         <div class="form-group">
             <label>Tone Frequency: <span id="morseToneFreqLabel">700</span> Hz</label>
@@ -154,10 +179,16 @@
         </div>
     </div>
 
-    <div class="section">
+    <div class="section" id="morseHFNote">
         <p class="info-text morse-hf-note">
             CW on HF (1-30 MHz) requires an HF-capable SDR path (direct sampling or upconverter)
             and an appropriate antenna.
+        </p>
+    </div>
+    <div class="section" id="morseEnvelopeNote" style="display: none;">
+        <p class="info-text" style="font-size: 11px; color: #ffaa00; line-height: 1.5;">
+            OOK Envelope mode uses AM demodulation to detect carrier on/off keying.
+            Suitable for ISM-band (315/433/868/915 MHz) Morse transmitters.
         </p>
     </div>
 


### PR DESCRIPTION
## OOK/AM Envelope Detection Mode for Morse Decoder

Adds a second detection mode to the Morse decoder for OOK (on-off keying) signals on ISM bands, while preserving the existing CW Goertzel path completely unchanged.

### What changed

- **`EnvelopeDetector` class** — RMS envelope detector for AM-demodulated OOK signals
- **Dual detection paths in `MorseDecoder.process_block()`** — envelope uses direct magnitude threshold with hysteresis; Goertzel path is untouched
- **Conditional gap thresholds** — `2.0/5.0` (char/word) for envelope only; Goertzel keeps `2.6/6.0`
- **Conditional frequency validation** — `max_mhz=1766` for envelope (ISM), `30` for Goertzel (HF)
- **Route updates** — `detect_mode` validated before frequency; envelope uses AM demod + 48kHz sample rate
- **Frontend** — detection mode toggle, ISM presets (315/433/868/915 MHz), mode-aware controls
- **8 new tests** — `TestEnvelopeDetector` (5 unit tests) + `TestEnvelopeMorseDecoder` (3 integration tests)

### Review feedback addressed

| # | Issue | Resolution |
|---|-------|-----------|
| 1 (Critical) | Stale base | Rebuilt from scratch on current `main` (lifecycle state machine, keyword args, device fallback) |
| 5 (High) | Gap thresholds changed globally | Now conditional: `2.0/5.0` envelope only, `2.6/6.0` Goertzel unchanged |
| 6 (High) | Frequency validation mismatch | `freq_max = 1766.0 if detect_mode == 'envelope' else 30.0` |
| 9 (Medium) | No tests | 8 tests added for `EnvelopeDetector` + envelope-mode decoder |
| Suggestion | Split into two PRs | Done — this PR is Morse-only. RF Fax will be a separate PR. |

### Files changed (5)

- `utils/morse.py` — `EnvelopeDetector`, `detect_mode` throughout decoder pipeline
- `routes/morse.py` — validation, conditional freq limits, AM demod for envelope
- `templates/partials/modes/morse.html` — detection mode toggle, ISM presets
- `static/js/modes/morse.js` — `setDetectMode()` UI logic
- `tests/test_morse.py` — 8 new passing tests