### PR TITLE
fix(sensor): replace static NodeList loops causing page freeze and removeChild TypeError

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5341,8 +5341,11 @@
                         // Clear existing output
                         output.innerHTML = '<div class="placeholder signal-empty-state" style="display: none;"></div>';
                     } else {
-                        alert('Error: ' + data.message);
+                        showInfo('Error: ' + (data.message || 'Failed to start sensor'));
                     }
+                })
+                .catch(err => {
+                    showInfo('Error starting sensor: ' + err.message);
                 });
         }
 
@@ -5580,8 +5583,8 @@
 
             // Keep list manageable
             const cards = output.querySelectorAll('.signal-card');
-            while (cards.length > 100) {
-                output.removeChild(output.lastChild);
+            for (let i = cards.length - 1; i >= 100; i--) {
+                cards[i].remove();
             }
         }
 
@@ -5864,14 +5867,8 @@
 
             // Limit to max 50 unique meters (cards won't pile up since we update in place)
             const cards = output.querySelectorAll('.signal-card.meter-aggregated');
-            while (cards.length > 50) {
-                // Remove oldest card (last one)
-                const oldestCard = output.querySelector('.signal-card.meter-aggregated:last-of-type');
-                if (oldestCard) {
-                    output.removeChild(oldestCard);
-                } else {
-                    break;
-                }
+            for (let i = cards.length - 1; i >= 50; i--) {
+                cards[i].remove();
             }
         }
 
@@ -7055,8 +7052,8 @@
 
             // Limit messages displayed (keep placeholder/empty-state)
             const cards = output.querySelectorAll('.signal-card');
-            while (cards.length > 100) {
-                output.removeChild(cards[cards.length - 1]);
+            for (let i = cards.length - 1; i >= 100; i--) {
+                cards[i].remove();
             }
         }
 
@@ -7420,7 +7417,7 @@
 
             // Limit displayed devices
             while (content.children.length > 50) {
-                content.removeChild(content.lastChild);
+                content.lastElementChild.remove();
             }
         }
 
@@ -10707,7 +10704,7 @@
 
             // Keep log manageable
             while (logEl.children.length > 100) {
-                logEl.removeChild(logEl.lastChild);
+                logEl.lastElementChild.remove();
             }
 
             // Update map if position data


### PR DESCRIPTION
## Summary

- Fixes infinite loop / page freeze in `addSensorReading` and 3 other list-trimming spots that used `querySelectorAll` (static NodeList) inside a `while (.length > N)` condition — the length never decreases so the loop never exits
- Fixes `TypeError: Failed to execute 'removeChild' on 'Node': parameter 1 is not of type 'Node'` caused by `removeChild(lastChild)` where `lastChild` can be a text node rather than a signal card element
- Replaces blocking `alert()` with `showInfo()` for sensor start errors so the page doesn't lock up on failure
- Adds `.catch()` to the `/start_sensor` fetch so network errors surface cleanly instead of leaving the UI in a broken state

## Affected areas

| Location | Fix |
|----------|-----|
| `addSensorReading` card trimmer | `for` loop over static NodeList by index |
| rtlamr meter card trimmer | same |
| AIS/Recon device list trimmer | `lastElementChild.remove()` instead of `lastChild` |
| APRS log trimmer | `lastElementChild.remove()` instead of `lastChild` |

## Test plan

- [ ] Run sensor mode with 100+ decodes and confirm no page freeze or console TypeError
- [ ] Trigger a sensor start failure (e.g. wrong device) and confirm error appears inline, not as a blocking alert
- [ ] Navigate away and back during sensor operation — confirm UI state is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)