### PR TITLE
fix(meshcore): add to nav and fix welcome card styling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -431,8 +431,8 @@
                                 <span class="mode-name">Meshtastic</span>
                             </button>
                             <button class="mode-card mode-card-sm" onclick="selectMode('meshcore')">
-                                <div class="mode-card-icon">📡</div>
-                                <div class="mode-card-label">Meshcore</div>
+                                <span class="mode-icon icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="6" cy="18" r="2"/><circle cx="18" cy="18" r="2"/><path d="M8 6h8M6 8v8M18 8v8M8 18h8"/></svg></span>
+                                <span class="mode-name">Meshcore</span>
                             </button>
                         </div>
                     </div>

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -135,6 +135,7 @@
             {{ mode_item('bt_locate', 'BT Locate', '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="10" r="3"/><path d="M12 21.7C17.3 17 20 13 20 10a8 8 0 1 0-16 0c0 3 2.7 7 8 11.7z"/><path d="M9.5 8.5l3 3 2-4-2 4-3 3"/></svg>') }}
             {{ mode_item('wifi_locate', 'WF Locate', '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><circle cx="12" cy="20" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="10" r="2"/><path d="M12 14v-2"/></svg>') }}
             {{ mode_item('meshtastic', 'Meshtastic', '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="3"/><path d="M12 2v4m0 12v4M2 12h4m12 0h4"/></svg>') }}
+            {{ mode_item('meshcore', 'Meshcore', '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="6" cy="18" r="2"/><circle cx="18" cy="18" r="2"/><path d="M8 6h8M6 8v8M18 8v8M8 18h8"/></svg>') }}
         </div>
     </div>
 
@@ -271,6 +272,7 @@
         {{ mobile_item('bt_locate', 'Locate', '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="10" r="3"/><path d="M12 21.7C17.3 17 20 13 20 10a8 8 0 1 0-16 0c0 3 2.7 7 8 11.7z"/></svg>') }}
         {{ mobile_item('wifi_locate', 'WF Loc', '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><circle cx="12" cy="20" r="1" fill="currentColor"/><circle cx="12" cy="10" r="2"/></svg>') }}
         {{ mobile_item('meshtastic', 'Mesh', '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="3"/><path d="M12 2v4m0 12v4M2 12h4m12 0h4"/></svg>') }}
+        {{ mobile_item('meshcore', 'Meshcore', '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="6" cy="18" r="2"/><circle cx="18" cy="18" r="2"/><path d="M8 6h8M6 8v8M18 8v8M8 18h8"/></svg>') }}
     </div>
 
     {# Intel Group #}


### PR DESCRIPTION
## Summary
- Added Meshcore to the desktop Wireless dropdown nav (after Meshtastic)
- Added Meshcore to the mobile bottom nav
- Fixed the welcome card: replaced non-standard `div.mode-card-icon` (emoji) / `div.mode-card-label` markup with the correct `span.mode-icon.icon` (SVG) / `span.mode-name` pattern used by all other modes — this was causing wrong font and colour rendering

## Test plan
- [ ] Meshcore appears in the Wireless dropdown in the desktop nav
- [ ] Meshcore appears in the mobile nav bar
- [ ] Meshcore welcome card on the main screen shows correct font and colour (matching other mode cards)
- [ ] Clicking Meshcore in nav and welcome card correctly switches to the mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)