### PR TITLE
fix(meshcore): show mode panel when active

### DIFF
--- a/static/css/modes/meshcore.css
+++ b/static/css/modes/meshcore.css
@@ -1,10 +1,14 @@
 /* Meshcore mode — scoped styles */
 
 #meshcoreMode {
-    display: flex;
-    flex-direction: column;
+    display: none;
+    flex-direction: row;
     height: 100%;
     gap: 0;
+}
+
+#meshcoreMode.active {
+    display: flex !important;
 }
 
 /* ── Sidebar ── */


### PR DESCRIPTION
## Summary
- `meshcore.css` was missing `#meshcoreMode.active { display: flex !important; }` — the rule that makes the mode panel visible when selected
- The `meshcoreMode` div starts with an inline `style="display:none"` and the `.active` class is toggled on mode switch, but without the CSS rule to match, the panel never appeared
- Also corrected the base CSS `flex-direction` from `column` to `row` (sidebar + main panel sit side by side)

## Result
- Selecting Meshcore now renders the connection sidebar (Serial/TCP/BLE, contacts, nodes) and main chat/map panel correctly instead of falling back to the generic sidebar

## Test plan
- [ ] Switch to Meshcore mode — connection sidebar with transport tabs (Serial/TCP/BLE), contacts, and nodes sections should be visible
- [ ] Generic "Collapse Sidebar / Kill All Processes" sidebar should be hidden while in Meshcore mode
- [ ] Switching away from Meshcore restores the generic sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)