### PR TITLE
fix(meshcore): move UI into visuals container, fix layout

### DIFF
--- a/static/css/modes/meshcore.css
+++ b/static/css/modes/meshcore.css
@@ -1,14 +1,19 @@
 /* Meshcore mode — scoped styles */
 
-#meshcoreMode {
-    display: none;
+/* Override the shared mesh-visuals-container column layout */
+#meshcoreVisuals {
     flex-direction: row;
-    height: 100%;
+    padding: 0;
     gap: 0;
 }
 
-#meshcoreMode.active {
-    display: flex !important;
+#meshcoreMode {
+    display: flex;
+    flex-direction: row;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    gap: 0;
 }
 
 /* ── Sidebar ── */

--- a/templates/index.html
+++ b/templates/index.html
@@ -779,7 +779,6 @@
                 {% include 'partials/modes/spy-stations.html' %}
 
                 {% include 'partials/modes/meshtastic.html' %}
-                {% include 'partials/modes/meshcore.html' %}
 
                 {% include 'partials/modes/websdr.html' %}
 
@@ -2366,6 +2365,7 @@
 
                 <!-- Meshcore Dashboard -->
                 <div id="meshcoreVisuals" class="mesh-visuals-container" style="display: none;">
+                    {% include 'partials/modes/meshcore.html' %}
                 </div>
 
                 <!-- SSTV Decoder Dashboard -->

--- a/templates/partials/modes/meshcore.html
+++ b/templates/partials/modes/meshcore.html
@@ -1,5 +1,5 @@
 {# Meshcore Mode Partial #}
-<div id="meshcoreMode" class="mode-content" style="display:none; flex-direction: row; height: 100%;">
+<div id="meshcoreMode" style="display:flex; flex-direction: row; flex: 1; min-height: 0; overflow: hidden;">
 
   {# ── Sidebar ── #}
   <div class="meshcore-sidebar">


### PR DESCRIPTION
## Summary
- The Meshcore partial was included inside the generic `.sidebar` div, which gets hidden by `mesh-sidebar-hidden` when Meshcore mode is active — so the UI was always invisible
- Moved `{% include 'partials/modes/meshcore.html' %}` to inside `#meshcoreVisuals` (inside the output panel), matching the exact same pattern as Meshtastic
- Updated the partial's outer div to `display:flex` always (visibility is now controlled by the parent `meshcoreVisuals` container)
- Added `#meshcoreVisuals` CSS override to cancel the shared `mesh-visuals-container` column direction and 16px padding, since Meshcore uses its own sidebar+main-panel row layout

## Result
The Meshcore interface (connection sidebar, Messages/Map/Repeaters/Telemetry tabs) now renders correctly at full width when the mode is selected.

## Test plan
- [ ] Selecting Meshcore shows the full UI: left sidebar (Connection/Contacts/Nodes) + right main panel (tabs)
- [ ] The layout fills the available screen width correctly
- [ ] Switching away from Meshcore hides the UI and restores the normal output panel
- [ ] Meshtastic mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)