### PR TITLE
fix(meshcore): add mesh-sidebar-hidden rules to meshcore.css

### DIFF
--- a/static/css/modes/meshcore.css
+++ b/static/css/modes/meshcore.css
@@ -1,5 +1,25 @@
 /* Meshcore mode — scoped styles */
 
+/* ── Sidebar hiding (same rules as meshtastic.css — needed here since
+      meshtastic.css is only lazily loaded when that mode is visited) ── */
+.main-content.mesh-sidebar-hidden {
+    display: flex !important;
+    flex-direction: column !important;
+}
+
+.main-content.mesh-sidebar-hidden > .sidebar {
+    display: none !important;
+    width: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+}
+
+.main-content.mesh-sidebar-hidden > .output-panel {
+    flex: 1 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+}
+
 /* ── Container overrides ── */
 #meshcoreVisuals {
     flex-direction: column;


### PR DESCRIPTION
## Summary
Mode CSS files are lazily loaded — `meshtastic.css` is only fetched when Meshtastic mode is visited. The three `mesh-sidebar-hidden` rules that hide the generic sidebar and make the output panel fill the screen lived exclusively in `meshtastic.css`. Switching directly to Meshcore without visiting Meshtastic first meant those rules were never loaded, leaving the generic sidebar visible and the output panel too narrow for the strip layout to render correctly.

Fix: duplicate the three rules into `meshcore.css` so they are guaranteed present whenever Meshcore is active.

## Test plan
- [ ] Switch directly to Meshcore (without visiting Meshtastic first) — generic sidebar should be hidden, output panel fills screen width
- [ ] Connection strip renders as a single horizontal row, not wrapped vertically
- [ ] Meshtastic mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)