### PR TITLE
fix(meshcore): layout height, connection polling, and modal visibility

### DIFF
--- a/static/css/modes/meshcore.css
+++ b/static/css/modes/meshcore.css
@@ -20,9 +20,13 @@
     max-width: 100% !important;
 }
 
-/* ── Container overrides ── */
+/* ── Visuals container (base rules duplicated from meshtastic.css — lazy-load safety) ── */
 #meshcoreVisuals {
+    display: flex;
     flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
     padding: 0;
     gap: 0;
 }

--- a/static/js/modes/meshcore.js
+++ b/static/js/modes/meshcore.js
@@ -86,9 +86,21 @@ const MeshCore = (function () {
             body.address = document.getElementById('meshcoreBleSelect').value || null;
         }
         try {
-            await fetch('/meshcore/connect', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
             _updateStatusUI('connecting');
-        } catch (e) { console.error('Connect failed:', e); }
+            await fetch('/meshcore/connect', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+            _pollUntilConnected(0);
+        } catch (e) {
+            _updateStatusUI('error', 'Connection failed');
+            console.error('Connect failed:', e);
+        }
+    }
+
+    function _pollUntilConnected(attempts) {
+        if (_connected || attempts > 15) return;
+        setTimeout(async () => {
+            await _checkStatus();
+            if (!_connected) _pollUntilConnected(attempts + 1);
+        }, 2000);
     }
 
     async function disconnect() {
@@ -383,23 +395,32 @@ const MeshCore = (function () {
                 container.appendChild(arrow);
             }
         });
-        modal.style.display = 'flex';
+        _openModal(modal);
     }
 
     function closeTraceroute() {
-        const modal = document.getElementById('meshcoreTracerouteModal');
-        if (modal) modal.style.display = 'none';
+        _closeModal(document.getElementById('meshcoreTracerouteModal'));
     }
 
     // ── Contacts ───────────────────────────────────────────────────────────
     function showAddContact() {
-        const modal = document.getElementById('meshcoreAddContactModal');
-        if (modal) modal.style.display = 'flex';
+        _openModal(document.getElementById('meshcoreAddContactModal'));
     }
 
     function closeAddContact() {
-        const modal = document.getElementById('meshcoreAddContactModal');
-        if (modal) modal.style.display = 'none';
+        _closeModal(document.getElementById('meshcoreAddContactModal'));
+    }
+
+    function _openModal(modal) {
+        if (!modal) return;
+        modal.style.display = '';
+        requestAnimationFrame(() => modal.classList.add('show'));
+    }
+
+    function _closeModal(modal) {
+        if (!modal) return;
+        modal.classList.remove('show');
+        setTimeout(() => { modal.style.display = 'none'; }, 200);
     }
 
     async function saveContact() {


### PR DESCRIPTION
## Summary

- **Layout fills height**: `#meshcoreVisuals` in `meshcore.css` was only setting override properties (`padding`, `gap`, `flex-direction`) but not the base ones (`flex: 1`, `min-height: 0`, `overflow: hidden`) — those were defined in `meshtastic.css` which isn't loaded when visiting Meshcore directly
- **Connection status**: After clicking Connect the UI was stuck at "Connecting..." because nothing polled the backend. Now polls `/meshcore/status` every 2s (up to 30s) until connected or error
- **Modals now visible**: `signal-details-modal` uses `opacity:0; visibility:hidden` + `.show` class to reveal. Setting `style.display = 'flex'` only undid `display:none` but left the modal invisible. Fixed with `_openModal`/`_closeModal` helpers that use the `.show` class

## Test plan

- [ ] Switch to Meshcore mode without first visiting Meshtastic — content fills full panel height
- [ ] Click Connect — status transitions from Connecting... to Connected (or Error) without staying stuck
- [ ] Click + Contact — modal appears and is interactive
- [ ] Close modal — modal dismisses smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)