### PR TITLE
fix(meshcore): show error when connection times out

### DIFF
--- a/static/js/modes/meshcore.js
+++ b/static/js/modes/meshcore.js
@@ -96,7 +96,11 @@ const MeshCore = (function () {
     }
 
     function _pollUntilConnected(attempts) {
-        if (_connected || attempts > 15) return;
+        if (_connected) return;
+        if (attempts > 15) {
+            _updateStatusUI('error', 'Connection timed out');
+            return;
+        }
         setTimeout(async () => {
             await _checkStatus();
             if (!_connected) _pollUntilConnected(attempts + 1);


### PR DESCRIPTION
## Summary

When Connect is clicked and the device never responds, the polling loop exits silently after 30s, leaving the status stuck on "Connecting...". Now shows "Connection timed out" with an error dot instead.

## Test plan

- [ ] Click Connect with no device attached — after ~30s status changes to "Connection timed out" with red dot
- [ ] Connect button re-enables so the user can retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)