### PR TITLE
fix(meshcore): call scan_ble_sync() in BLE scan route

### DIFF
--- a/routes/meshcore.py
+++ b/routes/meshcore.py
@@ -93,7 +93,7 @@ def ports():
 def ble_scan():
     if not is_meshcore_available():
         return api_error("meshcore not installed", 503)
-    devices = _client().scan_ble()
+    devices = _client().scan_ble_sync()
     return jsonify({"devices": devices})
 
 


### PR DESCRIPTION
## Summary

The `/meshcore/ble/scan` route called `_client().scan_ble()` but the method on `MeshCoreClient` is `scan_ble_sync()`. Every scan request was throwing an `AttributeError` and returning a 500.

## Test plan

- [ ] BLE tab → Scan → dropdown populates with nearby MeshCore devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)