### PR TITLE
fix(meshcore): fix BLE scan 500 and allow scan before connect

### DIFF
--- a/routes/meshcore.py
+++ b/routes/meshcore.py
@@ -93,7 +93,7 @@ def ports():
 def ble_scan():
     if not is_meshcore_available():
         return api_error("meshcore not installed", 503)
-    devices = _client().scan_ble_sync()
+    devices = _client().scan_ble()
     return jsonify({"devices": devices})
 
 

--- a/utils/meshcore.py
+++ b/utils/meshcore.py
@@ -413,10 +413,19 @@ class MeshcoreClient:
             self._worker.request_traceroute(node_id)
 
     def scan_ble(self) -> list[dict]:
-        """Scan for BLE MeshCore devices; returns list of found device dicts."""
+        """Scan for BLE MeshCore devices; works with or without an active connection."""
         if self._worker:
             return self._worker.scan_ble_sync()
-        return []
+        # No worker yet — run a one-shot scan directly
+        import asyncio
+
+        from utils.meshcore_client import _scan_ble
+
+        try:
+            return asyncio.run(_scan_ble())
+        except Exception as exc:
+            logger.warning("BLE scan failed: %s", exc)
+            return []
 
 
 _client: MeshcoreClient | None = None


### PR DESCRIPTION
## Summary

Two bugs fixed:

1. **500 on every scan**: Previous fix wrongly changed route to call `scan_ble_sync()` which doesn't exist on `MeshcoreClient` (it's on `AsyncWorker`). Reverted to `scan_ble()`.
2. **Scan returns nothing before Connect**: `scan_ble()` delegated to the worker and returned `[]` if no worker existed. Now falls back to a one-shot `asyncio.run(_scan_ble())` so scanning works independently of connection state.

## Test plan

- [ ] BLE tab → Scan without pressing Connect first → device list populates
- [ ] No 500 errors in server logs during scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)