### PR TITLE
fix(meshcore): surface backend error messages and extend polling window

### DIFF
--- a/routes/meshcore.py
+++ b/routes/meshcore.py
@@ -48,7 +48,11 @@ def status():
             }
         )
     c = _client()
-    return jsonify({"available": True, "state": c.get_state().value})
+    state, message = c.get_state()
+    payload = {"available": True, "state": state.value}
+    if message:
+        payload["message"] = message
+    return jsonify(payload)
 
 
 @meshcore_bp.route("/connect", methods=["POST"])

--- a/static/js/modes/meshcore.js
+++ b/static/js/modes/meshcore.js
@@ -97,7 +97,8 @@ const MeshCore = (function () {
 
     function _pollUntilConnected(attempts) {
         if (_connected) return;
-        if (attempts > 15) {
+        if (attempts > 45) {
+            // Backend retry window (5+15+45s) has elapsed — give up
             _updateStatusUI('error', 'Connection timed out');
             return;
         }

--- a/utils/meshcore.py
+++ b/utils/meshcore.py
@@ -250,6 +250,7 @@ class MeshcoreClient:
 
     def __init__(self) -> None:
         self._state = ConnectionState.DISCONNECTED
+        self._status_message: str | None = None
         self._config: ConnectionConfig | None = None
         self._event_queue: queue.Queue = queue.Queue(maxsize=500)
         self._nodes: dict[str, MeshcoreNode] = {}
@@ -261,14 +262,15 @@ class MeshcoreClient:
 
     # -- State --
 
-    def get_state(self) -> ConnectionState:
-        """Return the current connection state."""
+    def get_state(self) -> tuple[ConnectionState, str | None]:
+        """Return the current connection state and last status message."""
         with self._lock:
-            return self._state
+            return self._state, self._status_message
 
     def _set_state(self, state: ConnectionState, **extra) -> None:
         with self._lock:
             self._state = state
+            self._status_message = extra.get("message")
         # Push the status event OUTSIDE the lock (avoids deadlock; _push is queue-based)
         payload: dict = {"state": state.value}
         payload.update(extra)


### PR DESCRIPTION
## Summary

- **Status message stored**: `MeshcoreClient` now persists the last status message so it can be returned by the `/status` endpoint even after the SSE event is gone
- **Status endpoint returns message**: Frontend now shows the actual failure reason (e.g. "Connection failed after retries: ...") instead of a generic "Error"
- **Polling extended to 90s**: Backend retries for up to 65s (5+15+45s delays); JS was giving up at 30s and showing a premature "Connection timed out"

## Test plan

- [ ] BLE connect with device out of range → eventually shows actual backend error message
- [ ] Error message is descriptive, not just "Error"
- [ ] Successful BLE connect still works and shows Connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)