### PR TITLE
debug(meshcore): enable BLE debug and pre-disconnect before connect

### DIFF
--- a/utils/meshcore_client.py
+++ b/utils/meshcore_client.py
@@ -107,7 +107,20 @@ class AsyncWorker:
             self._mc = await MeshCore.create_tcp(host=cfg.host, port=cfg.port, debug=False)
             transport, device = "tcp", f"{cfg.host}:{cfg.port}"
         elif isinstance(cfg, BLEConfig):
-            self._mc = await MeshCore.create_ble(address=cfg.device_address, debug=False)
+            # Disconnect any existing BlueZ connection so bleak gets a clean slate
+            if cfg.device_address:
+                try:
+                    import subprocess
+
+                    subprocess.run(
+                        ["bluetoothctl", "disconnect", cfg.device_address],
+                        timeout=3,
+                        capture_output=True,
+                    )
+                    await asyncio.sleep(1.0)
+                except Exception:
+                    pass
+            self._mc = await MeshCore.create_ble(address=cfg.device_address, debug=True)
             transport, device = "ble", cfg.device_address or "auto"
         else:
             raise RuntimeError(f"Unknown connection config type: {type(cfg)}")


### PR DESCRIPTION
## Summary

Diagnostic PR to identify the BLE ATT 0x0e write failure:

- Enable `debug=True` on `MeshCore.create_ble()` so the meshcore library logs exactly what BLE operations it's performing
- Pre-disconnect any existing BlueZ connection via `bluetoothctl disconnect` before bleak connects — BlueZ may hold an active connection from the pairing session, causing the write to fail

## Test plan

- [ ] Connect BLE device — check server logs for verbose meshcore debug output
- [ ] Note whether the pre-disconnect fixes the ATT write error

🤖 Generated with [Claude Code](https://claude.com/claude-code)