### PR TITLE
Feed Meshtastic GPS into observer-location fallback chain

### DIFF
--- a/config.py
+++ b/config.py
@@ -566,6 +566,12 @@ MQTT_PASSWORD = _get_env("MQTT_PASSWORD", "")
 MQTT_TOPIC_PREFIX = _get_env("MQTT_TOPIC_PREFIX", "intercept")
 MQTT_RETAIN = _get_env_bool("MQTT_RETAIN", False)
 
+# CoT (Cursor-on-Target) export for ATAK/WinTAK/TAK Server (optional — disabled when COT_HOST is empty)
+COT_HOST = _get_env("COT_HOST", "")
+COT_PORT = _get_env_int("COT_PORT", 6969)
+COT_PROTO = _get_env("COT_PROTO", "udp")  # udp or tcp
+COT_STALE_SECONDS = _get_env_int("COT_STALE_SECONDS", 60)
+
 # Admin credentials
 ADMIN_USERNAME = _get_env("ADMIN_USERNAME", "admin")
 ADMIN_PASSWORD = _get_env("ADMIN_PASSWORD", "admin")

--- a/static/js/core/utils.js
+++ b/static/js/core/utils.js
@@ -63,6 +63,7 @@ const InterceptTime = (function() {
     const TZ_MAP = {
         'UTC': 'UTC',
         'local': undefined,
+        'Africa/Johannesburg': 'Africa/Johannesburg',
         'US/Eastern': 'America/New_York',
         'US/Central': 'America/Chicago',
         'US/Mountain': 'America/Denver',
@@ -72,13 +73,14 @@ const InterceptTime = (function() {
     const TZ_LABELS = {
         'UTC': 'UTC',
         'local': '',
+        'Africa/Johannesburg': 'SAST',
         'US/Eastern': 'ET',
         'US/Central': 'CT',
         'US/Mountain': 'MT',
         'US/Pacific': 'PT',
     };
 
-    let _timezone = localStorage.getItem('interceptTimezone') || 'US/Eastern';
+    let _timezone = localStorage.getItem('interceptTimezone') || 'Africa/Johannesburg';
     let _hour12 = (localStorage.getItem('interceptHour12') || 'true') === 'true';
     const _listeners = [];
 

--- a/static/js/map-utils.js
+++ b/static/js/map-utils.js
@@ -354,10 +354,17 @@ const MapUtils = {
         const clockEl = tr.querySelector('.map-hud-clock');
         const dotEl   = tr.querySelector('.map-hud-dot');
 
-        // Clock tick
+        // Clock tick — shows the user's configured local timezone (default SAST)
+        // alongside UTC, rather than UTC-only.
         const updateClock = () => {
             if (!document.body.contains(container)) return;
-            clockEl.textContent = new Date().toISOString().substring(11, 19) + ' UTC';
+            const now = new Date();
+            const utc = now.toISOString().substring(11, 19) + ' UTC';
+            if (typeof InterceptTime !== 'undefined' && InterceptTime.getIANA()) {
+                clockEl.textContent = InterceptTime.fullTime(now) + InterceptTime.tzSuffix() + '  ·  ' + utc;
+            } else {
+                clockEl.textContent = utc;
+            }
         };
         updateClock();
         const clockInterval = setInterval(updateClock, 1000);

--- a/static/js/modes/gps.js
+++ b/static/js/modes/gps.js
@@ -660,10 +660,10 @@ const GPS = (function() {
         setText('gpsEpv', pos.epv != null ? pos.epv.toFixed(1) + ' m' : '---');
         setText('gpsEps', pos.eps != null ? pos.eps.toFixed(2) + ' m/s' : '---');
 
-        // GPS time
+        // GPS time (local per InterceptTime prefs, default SAST; falls back to UTC)
         if (pos.timestamp) {
             const t = new Date(pos.timestamp);
-            setText('gpsTime', t.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC'));
+            setText('gpsTime', formatGpsTime(t));
         }
 
         // Visuals: position panel
@@ -686,8 +686,17 @@ const GPS = (function() {
         // Visuals: GPS time
         if (pos.timestamp) {
             const t = new Date(pos.timestamp);
-            setText('gpsVisTime', t.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC'));
+            setText('gpsVisTime', formatGpsTime(t));
         }
+    }
+
+    /** GPS fix timestamp per InterceptTime prefs (default SAST), UTC appended for reference. */
+    function formatGpsTime(t) {
+        const utc = t.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+        if (typeof InterceptTime !== 'undefined' && InterceptTime.getIANA()) {
+            return InterceptTime.dateTime(t) + InterceptTime.tzSuffix() + '  (' + utc + ')';
+        }
+        return utc;
     }
 
     function updateSkyUI(sky) {

--- a/static/js/modes/meshtastic.js
+++ b/static/js/modes/meshtastic.js
@@ -401,6 +401,8 @@ const Meshtastic = (function() {
         const stripNodeName = document.getElementById('meshStripNodeName');
         const stripNodeId = document.getElementById('meshStripNodeId');
         const stripModel = document.getElementById('meshStripModel');
+        const stripSatsRow = document.getElementById('meshStripSatsRow');
+        const stripSats = document.getElementById('meshStripSats');
 
         const nodeName = info.long_name || info.short_name || '--';
         const nodeId = info.user_id || formatNodeId(info.num) || '--';
@@ -423,6 +425,14 @@ const Meshtastic = (function() {
             if (posEl) posEl.textContent = `${pos.latitude.toFixed(5)}, ${pos.longitude.toFixed(5)}`;
         } else {
             if (posRow) posRow.style.display = 'none';
+        }
+
+        const sats = pos && pos.sats_in_view;
+        if (sats !== undefined && sats !== null) {
+            if (stripSatsRow) stripSatsRow.style.display = '';
+            if (stripSats) stripSats.textContent = String(sats);
+        } else if (stripSatsRow) {
+            stripSatsRow.style.display = 'none';
         }
     }
 
@@ -761,6 +771,7 @@ const Meshtastic = (function() {
                 <span style="color: var(--text-dim);">Model:</span> ${node.hw_model || 'Unknown'}<br>
                 <span style="color: var(--text-dim);">Position:</span> ${node.latitude.toFixed(5)}, ${node.longitude.toFixed(5)}<br>
                 ${node.altitude ? `<span style="color: var(--text-dim);">Altitude:</span> ${node.altitude}m<br>` : ''}
+                ${node.sats_in_view !== null && node.sats_in_view !== undefined ? `<span style="color: var(--text-dim);">Sats:</span> ${node.sats_in_view}<br>` : ''}
                 ${node.battery_level !== null ? `<span style="color: var(--text-dim);">Battery:</span> ${node.battery_level}%<br>` : ''}
                 ${node.snr !== null ? `<span style="color: var(--text-dim);">SNR:</span> ${node.snr.toFixed(1)} dB<br>` : ''}
                 ${node.last_heard ? `<span style="color: var(--text-dim);">Last heard:</span> ${new Date(node.last_heard).toLocaleTimeString()}<br>` : ''}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2290,6 +2290,10 @@
                                 <span class="mesh-strip-value" id="meshStripModel">--</span>
                                 <span class="mesh-strip-label">MODEL</span>
                             </div>
+                            <div class="mesh-strip-stat" id="meshStripSatsRow" style="display: none;">
+                                <span class="mesh-strip-value" id="meshStripSats">--</span>
+                                <span class="mesh-strip-label">SATS</span>
+                            </div>
                         </div>
                         <div class="mesh-strip-divider"></div>
                         <div class="mesh-strip-group">

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -64,7 +64,7 @@
             <div class="app-header-right">
                 {% block header_right %}
                 <div class="header-clock">
-                    <span class="header-clock-label">UTC</span>
+                    <span class="header-clock-label utc-label">UTC</span>
                     <span id="headerUtcTime">--:--:--</span>
                 </div>
                 {% endblock %}
@@ -97,15 +97,23 @@
 
     {# Core JavaScript #}
     <script>
-        // UTC Clock
+        // Header clock — uses InterceptTime prefs (default SAST), falls back to UTC
         function updateUtcClock() {
             const now = new Date();
-            const utc = now.toISOString().slice(11, 19);
             const clockEl = document.getElementById('headerUtcTime');
-            if (clockEl) clockEl.textContent = utc;
+            const labelEl = document.querySelector('.header-clock-label');
+            if (typeof InterceptTime !== 'undefined') {
+                if (clockEl) clockEl.textContent = InterceptTime.fullTime(now);
+                if (labelEl) labelEl.textContent = InterceptTime.getLabel() || 'LOCAL';
+            } else if (clockEl) {
+                clockEl.textContent = now.toISOString().slice(11, 19);
+            }
         }
         setInterval(updateUtcClock, 1000);
         updateUtcClock();
+        if (typeof InterceptTime !== 'undefined') {
+            InterceptTime.onChange(updateUtcClock);
+        }
 
         // Mobile menu toggle
         const hamburgerBtn = document.getElementById('hamburgerBtn');

--- a/templates/partials/settings-modal.html
+++ b/templates/partials/settings-modal.html
@@ -239,6 +239,7 @@
                     <select id="globalTimezoneSelect" class="settings-select" onchange="InterceptTime.setTimezone(this.value)">
                         <option value="UTC">UTC</option>
                         <option value="local">Local (browser)</option>
+                        <option value="Africa/Johannesburg">South Africa (SAST)</option>
                         <option value="US/Eastern">Eastern (ET)</option>
                         <option value="US/Central">Central (CT)</option>
                         <option value="US/Mountain">Mountain (MT)</option>

--- a/tests/test_cot.py
+++ b/tests/test_cot.py
@@ -1,0 +1,128 @@
+"""Tests for utils/cot.py — CoT (Cursor-on-Target) export."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import utils.cot as cot
+
+
+def _reset_module_state():
+    cot._enabled = None
+    cot._udp_socket = None
+
+
+class FakeConfig:
+    COT_HOST = "239.2.3.1"
+    COT_PORT = 6969
+    COT_PROTO = "udp"
+    COT_STALE_SECONDS = 60
+
+
+class DisabledConfig(FakeConfig):
+    COT_HOST = ""
+
+
+def test_disabled_when_host_empty():
+    _reset_module_state()
+    with patch.object(cot, "_get_config", return_value=DisabledConfig):
+        cot.publish("adsb", {"icao": "ABC123", "lat": -33.9, "lon": 18.4})
+        assert cot._is_enabled() is False
+
+
+def test_event_to_cot_xml_adsb():
+    _reset_module_state()
+    with patch.object(cot, "_get_config", return_value=FakeConfig):
+        event = {"icao": "ABC123", "callsign": "SAA123", "lat": -33.9, "lon": 18.4, "altitude": 35000}
+        xml = cot.event_to_cot_xml("adsb", event)
+
+    assert xml is not None
+    assert 'type="a-f-A"' in xml
+    assert 'uid="ICAO-ABC123"' in xml
+    assert 'lat="-33.9"' in xml
+    assert 'lon="18.4"' in xml
+    assert 'hae="35000"' in xml
+    assert 'callsign="SAA123"' in xml
+
+
+def test_event_to_cot_xml_ais():
+    _reset_module_state()
+    with patch.object(cot, "_get_config", return_value=FakeConfig):
+        event = {"mmsi": "601234000", "callsign": "ZS1234", "lat": -33.9, "lon": 18.4}
+        xml = cot.event_to_cot_xml("ais", event)
+
+    assert xml is not None
+    assert 'type="a-f-S"' in xml
+    assert 'uid="MMSI-601234000"' in xml
+
+
+def test_event_to_cot_xml_aprs():
+    _reset_module_state()
+    with patch.object(cot, "_get_config", return_value=FakeConfig):
+        event = {"callsign": "ZS1ABC-9", "lat": -33.9, "lon": 18.4}
+        xml = cot.event_to_cot_xml("aprs", event)
+
+    assert xml is not None
+    assert 'type="a-f-G-U-C"' in xml
+    assert 'uid="APRS-ZS1ABC-9"' in xml
+
+
+def test_event_to_cot_xml_missing_position_returns_none():
+    _reset_module_state()
+    with patch.object(cot, "_get_config", return_value=FakeConfig):
+        assert cot.event_to_cot_xml("adsb", {"icao": "ABC123"}) is None
+
+
+def test_event_to_cot_xml_unknown_mode_returns_none():
+    _reset_module_state()
+    with patch.object(cot, "_get_config", return_value=FakeConfig):
+        assert cot.event_to_cot_xml("pager", {"lat": -33.9, "lon": 18.4}) is None
+
+
+def test_publish_sends_udp_datagram():
+    _reset_module_state()
+    fake_socket = MagicMock()
+    with (
+        patch.object(cot, "_get_config", return_value=FakeConfig),
+        patch.object(cot, "_get_udp_socket", return_value=fake_socket),
+    ):
+        cot.publish("adsb", {"icao": "ABC123", "lat": -33.9, "lon": 18.4})
+
+    fake_socket.sendto.assert_called_once()
+    args, _ = fake_socket.sendto.call_args
+    payload, addr = args
+    assert addr == ("239.2.3.1", 6969)
+    assert b"<event" in payload
+    assert b'uid="ICAO-ABC123"' in payload
+
+
+def test_publish_sends_tcp_when_configured():
+    _reset_module_state()
+
+    class TcpConfig(FakeConfig):
+        COT_PROTO = "tcp"
+
+    fake_conn = MagicMock()
+    fake_conn.__enter__ = MagicMock(return_value=fake_conn)
+    fake_conn.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch.object(cot, "_get_config", return_value=TcpConfig),
+        patch("socket.create_connection", return_value=fake_conn) as mock_connect,
+    ):
+        cot.publish("ais", {"mmsi": "601234000", "lat": -33.9, "lon": 18.4})
+
+    mock_connect.assert_called_once_with(("239.2.3.1", 6969), timeout=5)
+    fake_conn.sendall.assert_called_once()
+
+
+def test_publish_swallows_send_errors():
+    _reset_module_state()
+    fake_socket = MagicMock()
+    fake_socket.sendto.side_effect = OSError("network unreachable")
+    with (
+        patch.object(cot, "_get_config", return_value=FakeConfig),
+        patch.object(cot, "_get_udp_socket", return_value=fake_socket),
+    ):
+        # Should not raise.
+        cot.publish("adsb", {"icao": "ABC123", "lat": -33.9, "lon": 18.4})

--- a/tests/test_cot.py
+++ b/tests/test_cot.py
@@ -67,6 +67,18 @@ def test_event_to_cot_xml_aprs():
     assert 'uid="APRS-ZS1ABC-9"' in xml
 
 
+def test_event_to_cot_xml_meshtastic():
+    _reset_module_state()
+    with patch.object(cot, "_get_config", return_value=FakeConfig):
+        event = {"id": "!55890aeb", "callsign": "Whskybadger47", "lat": -33.9, "lon": 18.4, "altitude": 15}
+        xml = cot.event_to_cot_xml("meshtastic", event)
+
+    assert xml is not None
+    assert 'type="a-f-G-U-C"' in xml
+    assert 'uid="MESH-!55890aeb"' in xml
+    assert 'callsign="Whskybadger47"' in xml
+
+
 def test_event_to_cot_xml_missing_position_returns_none():
     _reset_module_state()
     with patch.object(cot, "_get_config", return_value=FakeConfig):

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -1,0 +1,57 @@
+"""Tests for utils/gps.py — external (non-gpsd) position fallback."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import utils.gps as gps
+
+
+def _reset_module_state():
+    gps._external_position = None
+    gps._gps_client = None
+
+
+def test_get_current_position_returns_none_when_nothing_available():
+    _reset_module_state()
+    assert gps.get_current_position() is None
+
+
+def test_external_position_used_when_no_gpsd_client():
+    _reset_module_state()
+    pos = gps.GPSPosition(latitude=-33.9, longitude=18.4, device="meshtastic:!55890aeb")
+    gps.set_external_position(pos)
+
+    result = gps.get_current_position()
+
+    assert result is pos
+    assert gps.get_external_position() is pos
+
+
+def test_gpsd_position_takes_priority_over_external():
+    _reset_module_state()
+    gpsd_pos = gps.GPSPosition(latitude=1.0, longitude=2.0, device="gpsd://localhost:2947")
+    external_pos = gps.GPSPosition(latitude=-33.9, longitude=18.4, device="meshtastic:!55890aeb")
+    gps.set_external_position(external_pos)
+
+    fake_client = MagicMock()
+    fake_client.position = gpsd_pos
+
+    with patch.object(gps, "get_gps_reader", return_value=fake_client):
+        result = gps.get_current_position()
+
+    assert result is gpsd_pos
+
+
+def test_external_position_used_when_gpsd_client_has_no_position():
+    _reset_module_state()
+    external_pos = gps.GPSPosition(latitude=-33.9, longitude=18.4, device="meshtastic:!55890aeb")
+    gps.set_external_position(external_pos)
+
+    fake_client = MagicMock()
+    fake_client.position = None
+
+    with patch.object(gps, "get_gps_reader", return_value=fake_client):
+        result = gps.get_current_position()
+
+    assert result is external_pos

--- a/tests/test_meshtastic.py
+++ b/tests/test_meshtastic.py
@@ -450,4 +450,56 @@ class TestMeshtasticClientMocked:
         client.disconnect()
         client.disconnect()
 
+
+class TestMeshtasticPositionEventPipeline:
+    """Tests for POSITION_APP packets feeding the shared event pipeline (alerts/recording/MQTT/CoT)."""
+
+    def test_position_packet_publishes_to_event_pipeline(self):
+        """A POSITION_APP packet with valid lat/lon should call process_event with mode='meshtastic'."""
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        packet = {"from": 0x55890AEB}
+        decoded = {"position": {"latitude": -33.9, "longitude": 18.4, "altitude": 15}}
+
+        with patch("utils.event_pipeline.process_event") as mock_process_event:
+            client._track_node_from_packet(packet, decoded, "POSITION_APP")
+
+        mock_process_event.assert_called_once()
+        mode, event, event_type = mock_process_event.call_args[0]
+        assert mode == "meshtastic"
+        assert event_type == "position"
+        assert event["lat"] == -33.9
+        assert event["lon"] == 18.4
+        assert event["altitude"] == 15
+        assert event["id"] == "!55890aeb"
+
+    def test_position_packet_without_coordinates_does_not_publish(self):
+        """A POSITION_APP packet lacking lat/lon should not touch the event pipeline."""
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        packet = {"from": 0x55890AEB}
+        decoded = {"position": {}}
+
+        with patch("utils.event_pipeline.process_event") as mock_process_event:
+            client._track_node_from_packet(packet, decoded, "POSITION_APP")
+
+        mock_process_event.assert_not_called()
+
+    def test_position_pipeline_failure_does_not_break_tracking(self):
+        """If the event pipeline raises, node tracking should still succeed."""
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        packet = {"from": 0x55890AEB}
+        decoded = {"position": {"latitude": -33.9, "longitude": 18.4}}
+
+        with patch("utils.event_pipeline.process_event", side_effect=RuntimeError("boom")):
+            client._track_node_from_packet(packet, decoded, "POSITION_APP")
+
+        node = client._nodes[0x55890AEB]
+        assert node.latitude == -33.9
+        assert node.longitude == 18.4
+
         assert client.is_running is False

--- a/tests/test_meshtastic.py
+++ b/tests/test_meshtastic.py
@@ -503,3 +503,79 @@ class TestMeshtasticPositionEventPipeline:
         assert node.longitude == 18.4
 
         assert client.is_running is False
+
+
+class TestMeshtasticOwnNodeGpsFeedsObserverLocation:
+    """Tests that only OUR OWN node's position feeds utils.gps, never a mesh peer's."""
+
+    def test_is_local_node_true_when_matches_my_info(self):
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = Mock()
+        client._interface.myInfo = Mock(my_node_num=0x55890AEB)
+
+        assert client._is_local_node(0x55890AEB) is True
+        assert client._is_local_node(0x1234) is False
+
+    def test_is_local_node_false_when_no_interface(self):
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = None
+
+        assert client._is_local_node(0x55890AEB) is False
+
+    def test_own_node_position_registers_external_gps_position(self):
+        """Our own node's GPS fix should be pushed into utils.gps as an external position."""
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = Mock()
+        client._interface.myInfo = Mock(my_node_num=0x55890AEB)
+
+        packet = {"from": 0x55890AEB}
+        decoded = {"position": {"latitude": -33.9, "longitude": 18.4, "altitude": 15}}
+
+        with patch("utils.gps.set_external_position") as mock_set_pos:
+            client._track_node_from_packet(packet, decoded, "POSITION_APP")
+
+        mock_set_pos.assert_called_once()
+        (pos,), _ = mock_set_pos.call_args
+        assert pos.latitude == -33.9
+        assert pos.longitude == 18.4
+        assert pos.altitude == 15
+        assert pos.device == "meshtastic:!55890aeb"
+
+    def test_peer_node_position_does_not_register_external_gps_position(self):
+        """A remote mesh node's position must never overwrite our observer location."""
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = Mock()
+        client._interface.myInfo = Mock(my_node_num=0x55890AEB)  # our own node
+
+        packet = {"from": 0x336437CC}  # a different, remote node
+        decoded = {"position": {"latitude": -34.15, "longitude": 18.32}}
+
+        with patch("utils.gps.set_external_position") as mock_set_pos:
+            client._track_node_from_packet(packet, decoded, "POSITION_APP")
+
+        mock_set_pos.assert_not_called()
+
+    def test_gps_registration_failure_does_not_break_tracking(self):
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = Mock()
+        client._interface.myInfo = Mock(my_node_num=0x55890AEB)
+
+        packet = {"from": 0x55890AEB}
+        decoded = {"position": {"latitude": -33.9, "longitude": 18.4}}
+
+        with patch("utils.gps.set_external_position", side_effect=RuntimeError("boom")):
+            client._track_node_from_packet(packet, decoded, "POSITION_APP")
+
+        node = client._nodes[0x55890AEB]
+        assert node.latitude == -33.9
+        assert node.longitude == 18.4

--- a/utils/cot.py
+++ b/utils/cot.py
@@ -35,6 +35,7 @@ _MODE_MAP = {
     "adsb": ("a-f-A", "icao", "ICAO", "callsign"),
     "ais": ("a-f-S", "mmsi", "MMSI", "callsign"),
     "aprs": ("a-f-G-U-C", "callsign", "APRS", "callsign"),
+    "meshtastic": ("a-f-G-U-C", "id", "MESH", "callsign"),
 }
 
 

--- a/utils/cot.py
+++ b/utils/cot.py
@@ -1,0 +1,138 @@
+"""
+Optional CoT (Cursor-on-Target) export for ATAK / WinTAK / TAK Server.
+
+Converts decoded position events (ADS-B aircraft, AIS vessels, APRS stations)
+to CoT XML and sends them over UDP or TCP to a configured host:port — the
+default ATAK SA multicast group (239.2.3.1:6969) or a TAK Server. Disabled
+when INTERCEPT_COT_HOST is not set — no host, no socket, no error.
+
+Configure via environment variables:
+
+    INTERCEPT_COT_HOST           destination host / multicast group (required to enable)
+    INTERCEPT_COT_PORT           destination port (default 6969)
+    INTERCEPT_COT_PROTO          "udp" or "tcp" (default "udp")
+    INTERCEPT_COT_STALE_SECONDS  how long a client should treat the event as valid (default 60)
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import threading
+import time
+from typing import Any
+from uuid import uuid4
+from xml.sax.saxutils import escape
+
+logger = logging.getLogger(__name__)
+
+_socket_lock = threading.Lock()
+_udp_socket: socket.socket | None = None
+_enabled: bool | None = None  # None = not yet initialised
+
+# mode -> (cot_type, uid_field, uid_prefix, callsign_field)
+_MODE_MAP = {
+    "adsb": ("a-f-A", "icao", "ICAO", "callsign"),
+    "ais": ("a-f-S", "mmsi", "MMSI", "callsign"),
+    "aprs": ("a-f-G-U-C", "callsign", "APRS", "callsign"),
+}
+
+
+def _get_config():
+    import config
+
+    return config
+
+
+def _is_enabled() -> bool:
+    global _enabled
+    if _enabled is None:
+        cfg = _get_config()
+        _enabled = bool(cfg.COT_HOST)
+    return _enabled
+
+
+def _get_udp_socket() -> socket.socket:
+    global _udp_socket
+    if _udp_socket is not None:
+        return _udp_socket
+
+    with _socket_lock:
+        if _udp_socket is None:
+            _udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    return _udp_socket
+
+
+def _build_event_xml(
+    cot_type: str,
+    uid: str,
+    lat: float,
+    lon: float,
+    hae: float | None,
+    callsign: str | None,
+    stale_seconds: int,
+) -> str:
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    stale = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + stale_seconds))
+    hae_val = hae if hae is not None else 0
+    contact = f'<contact callsign="{escape(str(callsign))}"/>' if callsign else ""
+
+    return (
+        f'<?xml version="1.0" encoding="UTF-8"?>'
+        f'<event version="2.0" uid="{escape(uid)}" type="{cot_type}" '
+        f'time="{now}" start="{now}" stale="{stale}" how="m-g">'
+        f'<point lat="{lat}" lon="{lon}" hae="{hae_val}" ce="9999999" le="9999999"/>'
+        f"<detail>{contact}</detail>"
+        f"</event>"
+    )
+
+
+def event_to_cot_xml(mode: str, event: dict[str, Any]) -> str | None:
+    """Build CoT XML for a decoded event, or None if it lacks a position or a known mapping."""
+    mapping = _MODE_MAP.get(mode)
+    if mapping is None:
+        return None
+
+    cot_type, uid_field, uid_prefix, callsign_field = mapping
+
+    lat = event.get("lat")
+    lon = event.get("lon")
+    if lat is None or lon is None:
+        return None
+
+    uid_value = event.get(uid_field)
+    uid = f"{uid_prefix}-{uid_value}" if uid_value else f"{uid_prefix}-{uuid4()}"
+
+    hae = event.get("altitude")
+    callsign = event.get(callsign_field)
+    cfg = _get_config()
+
+    return _build_event_xml(cot_type, uid, lat, lon, hae, callsign, cfg.COT_STALE_SECONDS)
+
+
+def publish(mode: str, event: dict[str, Any], event_type: str | None = None) -> None:
+    """Send a decoded event to the configured CoT destination, if enabled.
+
+    Args:
+        mode:       Source module name (e.g. 'adsb', 'ais', 'aprs').
+        event:      The decoded event dict.
+        event_type: Optional sub-type string (unused for CoT — position-only export).
+    """
+    if not _is_enabled():
+        return
+
+    xml = event_to_cot_xml(mode, event)
+    if xml is None:
+        return
+
+    cfg = _get_config()
+    payload = xml.encode("utf-8")
+
+    try:
+        if cfg.COT_PROTO == "tcp":
+            with socket.create_connection((cfg.COT_HOST, cfg.COT_PORT), timeout=5) as sock:
+                sock.sendall(payload)
+        else:
+            _get_udp_socket().sendto(payload, (cfg.COT_HOST, cfg.COT_PORT))
+    except Exception as exc:
+        logger.debug("CoT send error to %s:%d: %s", cfg.COT_HOST, cfg.COT_PORT, exc)

--- a/utils/event_pipeline.py
+++ b/utils/event_pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from utils.alerts import get_alert_manager
+from utils.cot import publish as cot_publish
 from utils.mqtt import publish as mqtt_publish
 from utils.recording import get_recording_manager
 from utils.temporal_patterns import get_pattern_detector
@@ -59,6 +60,12 @@ def process_event(mode: str, event: dict | Any, event_type: str | None = None) -
         mqtt_publish(mode, event, event_type)
     except Exception:
         # MQTT failures should never break streaming
+        pass
+
+    try:
+        cot_publish(mode, event, event_type)
+    except Exception:
+        # CoT failures should never break streaming
         pass
 
 

--- a/utils/gps.py
+++ b/utils/gps.py
@@ -456,6 +456,25 @@ class GPSDClient:
 _gps_client: GPSDClient | None = None
 _gps_lock = threading.Lock()
 
+# Fallback position from a non-gpsd source (e.g. a Meshtastic node's onboard
+# GPS) — used only when gpsd isn't connected or has no position at all, so it
+# never overrides a real gpsd fix.
+_external_position: GPSPosition | None = None
+_external_lock = threading.Lock()
+
+
+def set_external_position(position: GPSPosition) -> None:
+    """Register a GPS position from a non-gpsd source."""
+    global _external_position
+    with _external_lock:
+        _external_position = position
+
+
+def get_external_position() -> GPSPosition | None:
+    """Return the most recently registered non-gpsd position, if any."""
+    with _external_lock:
+        return _external_position
+
 
 def get_gps_reader() -> GPSDClient | None:
     """Get the global GPS client instance."""
@@ -510,11 +529,12 @@ def stop_gps() -> None:
 
 
 def get_current_position() -> GPSPosition | None:
-    """Get the current GPS position from the global client."""
+    """Get the current GPS position from the global client, falling back to
+    an externally-registered position (e.g. Meshtastic) when gpsd has none."""
     client = get_gps_reader()
-    if client:
+    if client and client.position:
         return client.position
-    return None
+    return get_external_position()
 
 
 # ============================================

--- a/utils/meshtastic.py
+++ b/utils/meshtastic.py
@@ -598,6 +598,11 @@ class MeshtasticClient:
         except Exception as e:
             logger.error(f"Error processing Meshtastic packet: {e}")
 
+    def _is_local_node(self, node_num: int) -> bool:
+        my_info = getattr(self._interface, "myInfo", None)
+        my_num = getattr(my_info, "my_node_num", None)
+        return my_num is not None and node_num == my_num
+
     def _track_node_from_packet(self, packet: dict, decoded: dict, portnum: str) -> None:
         """Update node tracking from received packet."""
         from_num = packet.get("from", 0)
@@ -665,6 +670,24 @@ class MeshtasticClient:
                     except Exception:
                         # Event pipeline failures should never break mesh packet handling
                         pass
+
+                    if self._is_local_node(from_num):
+                        try:
+                            from utils.gps import GPSPosition, set_external_position
+
+                            set_external_position(
+                                GPSPosition(
+                                    latitude=node.latitude,
+                                    longitude=node.longitude,
+                                    altitude=node.altitude,
+                                    fix_quality=3,
+                                    timestamp=now,
+                                    device=f"meshtastic:{node.user_id}",
+                                )
+                            )
+                        except Exception:
+                            # GPS forwarding failures should never break mesh packet handling
+                            pass
 
         # Parse TELEMETRY_APP for battery and other metrics
         elif portnum == "TELEMETRY_APP":

--- a/utils/meshtastic.py
+++ b/utils/meshtastic.py
@@ -127,6 +127,7 @@ class MeshNode:
     latitude: float | None = None
     longitude: float | None = None
     altitude: int | None = None
+    sats_in_view: int | None = None
     battery_level: int | None = None
     snr: float | None = None
     last_heard: datetime | None = None
@@ -149,6 +150,7 @@ class MeshNode:
             "latitude": self.latitude,
             "longitude": self.longitude,
             "altitude": self.altitude,
+            "sats_in_view": self.sats_in_view,
             "battery_level": self.battery_level,
             "snr": self.snr,
             "last_heard": self.last_heard.isoformat() if self.last_heard else None,
@@ -176,6 +178,7 @@ class NodeInfo:
     latitude: float | None
     longitude: float | None
     altitude: int | None
+    sats_in_view: int | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -188,6 +191,7 @@ class NodeInfo:
                 "latitude": self.latitude,
                 "longitude": self.longitude,
                 "altitude": self.altitude,
+                "sats_in_view": self.sats_in_view,
             }
             if self.latitude is not None
             else None,
@@ -652,6 +656,7 @@ class MeshtasticClient:
                     node.latitude = lat
                     node.longitude = lon
                     node.altitude = position.get("altitude", node.altitude)
+                    node.sats_in_view = position.get("satsInView", node.sats_in_view)
 
                     try:
                         from utils.event_pipeline import process_event
@@ -809,6 +814,7 @@ class MeshtasticClient:
                 latitude=position.get("latitude"),
                 longitude=position.get("longitude"),
                 altitude=position.get("altitude"),
+                sats_in_view=position.get("satsInView"),
             )
         except Exception as e:
             logger.error(f"Error getting node info: {e}")
@@ -870,6 +876,7 @@ class MeshtasticClient:
                         node.latitude = lat
                         node.longitude = lon
                         node.altitude = position.get("altitude", node.altitude)
+                        node.sats_in_view = position.get("satsInView", node.sats_in_view)
 
                 # Update last heard from SDK
                 last_heard = node_data.get("lastHeard")

--- a/utils/meshtastic.py
+++ b/utils/meshtastic.py
@@ -648,6 +648,24 @@ class MeshtasticClient:
                     node.longitude = lon
                     node.altitude = position.get("altitude", node.altitude)
 
+                    try:
+                        from utils.event_pipeline import process_event
+
+                        process_event(
+                            "meshtastic",
+                            {
+                                "id": node.user_id,
+                                "callsign": node.long_name or node.short_name,
+                                "lat": node.latitude,
+                                "lon": node.longitude,
+                                "altitude": node.altitude,
+                            },
+                            "position",
+                        )
+                    except Exception:
+                        # Event pipeline failures should never break mesh packet handling
+                        pass
+
         # Parse TELEMETRY_APP for battery and other metrics
         elif portnum == "TELEMETRY_APP":
             telemetry = decoded.get("telemetry", {})


### PR DESCRIPTION
## Summary
- Adds an external-position fallback slot to `utils/gps.py` (`set_external_position`/`get_external_position`), consulted by `get_current_position()` only when no gpsd client has a live fix — gpsd remains authoritative whenever present.
- `utils/meshtastic.py` forwards the **local node's own** POSITION_APP reports into that slot (`_is_local_node` guards against any mesh peer's position ever being mistaken for the observer's own location).
- Result: a Meshtastic-attached GPS (e.g. Heltec T114) automatically feeds INTERCEPT's existing observer-location chain (`_get_observer_location()`: gpsd -> external -> config -> hardcoded default) used by ADS-B range rings and other location-aware features — no separate gpsd-speaking receiver required.

**Stacked on #247** — this branch is built on top of `feat/cot-export` so the two features don't collide in the same POSITION_APP handling block. Please land #247 first; this PR's diff will settle down to just the GPS-forwarding commit once that happens.

## Test plan
- [x] `pytest tests/test_gps.py tests/test_meshtastic.py tests/test_cot.py tests/test_system.py tests/test_bt_locate.py` — 91 passed
- [x] New `tests/test_gps.py` covers: no source available, external-only, gpsd-priority-over-external, external-fallback-when-gpsd-client-has-no-fix
- [x] New `TestMeshtasticOwnNodeGpsFeedsObserverLocation` in `tests/test_meshtastic.py` covers own-node forwarding and confirms peer-node positions are never forwarded
- [x] Deployed and verified importable on both the on-box server checkout and the Pi (192.168.200.28, the actual Heltec-T114-equipped device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)