### PR TITLE
Remove unused imports in dsc/decoder.py

### DIFF
--- a/utils/dsc/decoder.py
+++ b/utils/dsc/decoder.py
@@ -35,15 +35,10 @@ import numpy as np
 from scipy import signal as scipy_signal
 
 from .constants import (
-    DISTRESS_NATURE_CODES,
     DSC_AUDIO_SAMPLE_RATE,
     DSC_BAUD_RATE,
     DSC_MARK_FREQ,
     DSC_SPACE_FREQ,
-    FORMAT_CODES,
-    MIN_SYMBOLS_FOR_FORMAT,
-    TELECOMMAND_FORMATS,
-    VALID_EOS,
 )
 
 # Configure logging


### PR DESCRIPTION
## Summary
- \`ruff check\` flagged 4 unused imports (\`DISTRESS_NATURE_CODES\`, \`FORMAT_CODES\`, \`MIN_SYMBOLS_FOR_FORMAT\`, \`TELECOMMAND_FORMATS\`) plus 2 F811 redefinition warnings for \`VALID_EOS\` in \`utils/dsc/decoder.py\`, unrelated to any feature work — pre-existing lint dirt.
- No behavior change: the local \`VALID_EOS = {117, 122, 127}\` assignments were already the values in use; only the now-redundant module-level import is removed.

## Test plan
- [x] \`ruff check .\` — all checks pass
- [x] \`pytest -k dsc\` — 80 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)