### PR TITLE
Add South Africa (SAST) timezone option and default; fix UTC-only clocks

### DIFF
--- a/static/js/core/utils.js
+++ b/static/js/core/utils.js
@@ -63,6 +63,7 @@ const InterceptTime = (function() {
     const TZ_MAP = {
         'UTC': 'UTC',
         'local': undefined,
+        'Africa/Johannesburg': 'Africa/Johannesburg',
         'US/Eastern': 'America/New_York',
         'US/Central': 'America/Chicago',
         'US/Mountain': 'America/Denver',
@@ -72,13 +73,14 @@ const InterceptTime = (function() {
     const TZ_LABELS = {
         'UTC': 'UTC',
         'local': '',
+        'Africa/Johannesburg': 'SAST',
         'US/Eastern': 'ET',
         'US/Central': 'CT',
         'US/Mountain': 'MT',
         'US/Pacific': 'PT',
     };
 
-    let _timezone = localStorage.getItem('interceptTimezone') || 'US/Eastern';
+    let _timezone = localStorage.getItem('interceptTimezone') || 'Africa/Johannesburg';
     let _hour12 = (localStorage.getItem('interceptHour12') || 'true') === 'true';
     const _listeners = [];
 

--- a/static/js/map-utils.js
+++ b/static/js/map-utils.js
@@ -354,10 +354,17 @@ const MapUtils = {
         const clockEl = tr.querySelector('.map-hud-clock');
         const dotEl   = tr.querySelector('.map-hud-dot');
 
-        // Clock tick
+        // Clock tick — shows the user's configured local timezone (default SAST)
+        // alongside UTC, rather than UTC-only.
         const updateClock = () => {
             if (!document.body.contains(container)) return;
-            clockEl.textContent = new Date().toISOString().substring(11, 19) + ' UTC';
+            const now = new Date();
+            const utc = now.toISOString().substring(11, 19) + ' UTC';
+            if (typeof InterceptTime !== 'undefined' && InterceptTime.getIANA()) {
+                clockEl.textContent = InterceptTime.fullTime(now) + InterceptTime.tzSuffix() + '  ·  ' + utc;
+            } else {
+                clockEl.textContent = utc;
+            }
         };
         updateClock();
         const clockInterval = setInterval(updateClock, 1000);

--- a/static/js/modes/gps.js
+++ b/static/js/modes/gps.js
@@ -660,10 +660,10 @@ const GPS = (function() {
         setText('gpsEpv', pos.epv != null ? pos.epv.toFixed(1) + ' m' : '---');
         setText('gpsEps', pos.eps != null ? pos.eps.toFixed(2) + ' m/s' : '---');
 
-        // GPS time
+        // GPS time (local per InterceptTime prefs, default SAST; falls back to UTC)
         if (pos.timestamp) {
             const t = new Date(pos.timestamp);
-            setText('gpsTime', t.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC'));
+            setText('gpsTime', formatGpsTime(t));
         }
 
         // Visuals: position panel
@@ -686,8 +686,17 @@ const GPS = (function() {
         // Visuals: GPS time
         if (pos.timestamp) {
             const t = new Date(pos.timestamp);
-            setText('gpsVisTime', t.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC'));
+            setText('gpsVisTime', formatGpsTime(t));
         }
+    }
+
+    /** GPS fix timestamp per InterceptTime prefs (default SAST), UTC appended for reference. */
+    function formatGpsTime(t) {
+        const utc = t.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+        if (typeof InterceptTime !== 'undefined' && InterceptTime.getIANA()) {
+            return InterceptTime.dateTime(t) + InterceptTime.tzSuffix() + '  (' + utc + ')';
+        }
+        return utc;
     }
 
     function updateSkyUI(sky) {

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -64,7 +64,7 @@
             <div class="app-header-right">
                 {% block header_right %}
                 <div class="header-clock">
-                    <span class="header-clock-label">UTC</span>
+                    <span class="header-clock-label utc-label">UTC</span>
                     <span id="headerUtcTime">--:--:--</span>
                 </div>
                 {% endblock %}
@@ -97,15 +97,23 @@
 
     {# Core JavaScript #}
     <script>
-        // UTC Clock
+        // Header clock — uses InterceptTime prefs (default SAST), falls back to UTC
         function updateUtcClock() {
             const now = new Date();
-            const utc = now.toISOString().slice(11, 19);
             const clockEl = document.getElementById('headerUtcTime');
-            if (clockEl) clockEl.textContent = utc;
+            const labelEl = document.querySelector('.header-clock-label');
+            if (typeof InterceptTime !== 'undefined') {
+                if (clockEl) clockEl.textContent = InterceptTime.fullTime(now);
+                if (labelEl) labelEl.textContent = InterceptTime.getLabel() || 'LOCAL';
+            } else if (clockEl) {
+                clockEl.textContent = now.toISOString().slice(11, 19);
+            }
         }
         setInterval(updateUtcClock, 1000);
         updateUtcClock();
+        if (typeof InterceptTime !== 'undefined') {
+            InterceptTime.onChange(updateUtcClock);
+        }
 
         // Mobile menu toggle
         const hamburgerBtn = document.getElementById('hamburgerBtn');

--- a/templates/partials/settings-modal.html
+++ b/templates/partials/settings-modal.html
@@ -239,6 +239,7 @@
                     <select id="globalTimezoneSelect" class="settings-select" onchange="InterceptTime.setTimezone(this.value)">
                         <option value="UTC">UTC</option>
                         <option value="local">Local (browser)</option>
+                        <option value="Africa/Johannesburg">South Africa (SAST)</option>
                         <option value="US/Eastern">Eastern (ET)</option>
                         <option value="US/Central">Central (CT)</option>
                         <option value="US/Mountain">Mountain (MT)</option>


### PR DESCRIPTION
## Summary
- \`InterceptTime\` (the global timezone preference used across the app) only offered UTC / browser-local / US zones, defaulting to \`US/Eastern\`. Added \`Africa/Johannesburg\` (labelled SAST) as a selectable option in the settings modal and as the new default.
- Fixed two clocks that bypassed \`InterceptTime\` entirely and always rendered raw UTC regardless of the user's preference:
  - the per-map HUD clock in \`map-utils.js\` (top-right overlay on every dashboard map)
  - the GPS fix-time readouts in \`gps.js\` (sidebar + visuals panel)
  
  Both now show local time (per \`InterceptTime\`, SAST by default) with UTC appended for reference, instead of UTC-only.
- \`templates/layout/base.html\`'s header clock was fixed the same way for consistency, though no current route renders that template.

Non-SAST users are unaffected beyond the new default — anyone who already set a timezone preference in Settings keeps it (stored in \`localStorage\`); this only changes the out-of-the-box default and adds a previously-missing option.

## Test plan
- [x] \`node --check\` on all three edited JS files
- [x] Manual review of \`InterceptTime.onChange\` wiring — no route currently renders \`base.html\`, so that portion is inert but consistent with the rest of the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)