### PR TITLE
Feed Meshtastic GPS into observer-location fallback + show satellite count

### DIFF
--- a/static/js/modes/meshtastic.js
+++ b/static/js/modes/meshtastic.js
@@ -401,6 +401,8 @@ const Meshtastic = (function() {
         const stripNodeName = document.getElementById('meshStripNodeName');
         const stripNodeId = document.getElementById('meshStripNodeId');
         const stripModel = document.getElementById('meshStripModel');
+        const stripSatsRow = document.getElementById('meshStripSatsRow');
+        const stripSats = document.getElementById('meshStripSats');
 
         const nodeName = info.long_name || info.short_name || '--';
         const nodeId = info.user_id || formatNodeId(info.num) || '--';
@@ -423,6 +425,14 @@ const Meshtastic = (function() {
             if (posEl) posEl.textContent = `${pos.latitude.toFixed(5)}, ${pos.longitude.toFixed(5)}`;
         } else {
             if (posRow) posRow.style.display = 'none';
+        }
+
+        const sats = pos && pos.sats_in_view;
+        if (sats !== undefined && sats !== null) {
+            if (stripSatsRow) stripSatsRow.style.display = '';
+            if (stripSats) stripSats.textContent = String(sats);
+        } else if (stripSatsRow) {
+            stripSatsRow.style.display = 'none';
         }
     }
 
@@ -761,6 +771,7 @@ const Meshtastic = (function() {
                 <span style="color: var(--text-dim);">Model:</span> ${node.hw_model || 'Unknown'}<br>
                 <span style="color: var(--text-dim);">Position:</span> ${node.latitude.toFixed(5)}, ${node.longitude.toFixed(5)}<br>
                 ${node.altitude ? `<span style="color: var(--text-dim);">Altitude:</span> ${node.altitude}m<br>` : ''}
+                ${node.sats_in_view !== null && node.sats_in_view !== undefined ? `<span style="color: var(--text-dim);">Sats:</span> ${node.sats_in_view}<br>` : ''}
                 ${node.battery_level !== null ? `<span style="color: var(--text-dim);">Battery:</span> ${node.battery_level}%<br>` : ''}
                 ${node.snr !== null ? `<span style="color: var(--text-dim);">SNR:</span> ${node.snr.toFixed(1)} dB<br>` : ''}
                 ${node.last_heard ? `<span style="color: var(--text-dim);">Last heard:</span> ${new Date(node.last_heard).toLocaleTimeString()}<br>` : ''}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2290,6 +2290,10 @@
                                 <span class="mesh-strip-value" id="meshStripModel">--</span>
                                 <span class="mesh-strip-label">MODEL</span>
                             </div>
+                            <div class="mesh-strip-stat" id="meshStripSatsRow" style="display: none;">
+                                <span class="mesh-strip-value" id="meshStripSats">--</span>
+                                <span class="mesh-strip-label">SATS</span>
+                            </div>
                         </div>
                         <div class="mesh-strip-divider"></div>
                         <div class="mesh-strip-group">

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -1,0 +1,57 @@
+"""Tests for utils/gps.py — external (non-gpsd) position fallback."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import utils.gps as gps
+
+
+def _reset_module_state():
+    gps._external_position = None
+    gps._gps_client = None
+
+
+def test_get_current_position_returns_none_when_nothing_available():
+    _reset_module_state()
+    assert gps.get_current_position() is None
+
+
+def test_external_position_used_when_no_gpsd_client():
+    _reset_module_state()
+    pos = gps.GPSPosition(latitude=-33.9, longitude=18.4, device="meshtastic:!55890aeb")
+    gps.set_external_position(pos)
+
+    result = gps.get_current_position()
+
+    assert result is pos
+    assert gps.get_external_position() is pos
+
+
+def test_gpsd_position_takes_priority_over_external():
+    _reset_module_state()
+    gpsd_pos = gps.GPSPosition(latitude=1.0, longitude=2.0, device="gpsd://localhost:2947")
+    external_pos = gps.GPSPosition(latitude=-33.9, longitude=18.4, device="meshtastic:!55890aeb")
+    gps.set_external_position(external_pos)
+
+    fake_client = MagicMock()
+    fake_client.position = gpsd_pos
+
+    with patch.object(gps, "get_gps_reader", return_value=fake_client):
+        result = gps.get_current_position()
+
+    assert result is gpsd_pos
+
+
+def test_external_position_used_when_gpsd_client_has_no_position():
+    _reset_module_state()
+    external_pos = gps.GPSPosition(latitude=-33.9, longitude=18.4, device="meshtastic:!55890aeb")
+    gps.set_external_position(external_pos)
+
+    fake_client = MagicMock()
+    fake_client.position = None
+
+    with patch.object(gps, "get_gps_reader", return_value=fake_client):
+        result = gps.get_current_position()
+
+    assert result is external_pos

--- a/tests/test_meshtastic.py
+++ b/tests/test_meshtastic.py
@@ -451,3 +451,79 @@ class TestMeshtasticClientMocked:
         client.disconnect()
 
         assert client.is_running is False
+
+
+class TestMeshtasticOwnNodeGpsFeedsObserverLocation:
+    """Tests that only OUR OWN node's position feeds utils.gps, never a mesh peer's."""
+
+    def test_is_local_node_true_when_matches_my_info(self):
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = Mock()
+        client._interface.myInfo = Mock(my_node_num=0x55890AEB)
+
+        assert client._is_local_node(0x55890AEB) is True
+        assert client._is_local_node(0x1234) is False
+
+    def test_is_local_node_false_when_no_interface(self):
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = None
+
+        assert client._is_local_node(0x55890AEB) is False
+
+    def test_own_node_position_registers_external_gps_position(self):
+        """Our own node's GPS fix should be pushed into utils.gps as an external position."""
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = Mock()
+        client._interface.myInfo = Mock(my_node_num=0x55890AEB)
+
+        packet = {"from": 0x55890AEB}
+        decoded = {"position": {"latitude": -33.9, "longitude": 18.4, "altitude": 15}}
+
+        with patch("utils.gps.set_external_position") as mock_set_pos:
+            client._track_node_from_packet(packet, decoded, "POSITION_APP")
+
+        mock_set_pos.assert_called_once()
+        (pos,), _ = mock_set_pos.call_args
+        assert pos.latitude == -33.9
+        assert pos.longitude == 18.4
+        assert pos.altitude == 15
+        assert pos.device == "meshtastic:!55890aeb"
+
+    def test_peer_node_position_does_not_register_external_gps_position(self):
+        """A remote mesh node's position must never overwrite our observer location."""
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = Mock()
+        client._interface.myInfo = Mock(my_node_num=0x55890AEB)  # our own node
+
+        packet = {"from": 0x336437CC}  # a different, remote node
+        decoded = {"position": {"latitude": -34.15, "longitude": 18.32}}
+
+        with patch("utils.gps.set_external_position") as mock_set_pos:
+            client._track_node_from_packet(packet, decoded, "POSITION_APP")
+
+        mock_set_pos.assert_not_called()
+
+    def test_gps_registration_failure_does_not_break_tracking(self):
+        from utils.meshtastic import MeshtasticClient
+
+        client = MeshtasticClient()
+        client._interface = Mock()
+        client._interface.myInfo = Mock(my_node_num=0x55890AEB)
+
+        packet = {"from": 0x55890AEB}
+        decoded = {"position": {"latitude": -33.9, "longitude": 18.4}}
+
+        with patch("utils.gps.set_external_position", side_effect=RuntimeError("boom")):
+            client._track_node_from_packet(packet, decoded, "POSITION_APP")
+
+        node = client._nodes[0x55890AEB]
+        assert node.latitude == -33.9
+        assert node.longitude == 18.4

--- a/utils/gps.py
+++ b/utils/gps.py
@@ -456,6 +456,25 @@ class GPSDClient:
 _gps_client: GPSDClient | None = None
 _gps_lock = threading.Lock()
 
+# Fallback position from a non-gpsd source (e.g. a Meshtastic node's onboard
+# GPS) — used only when gpsd isn't connected or has no position at all, so it
+# never overrides a real gpsd fix.
+_external_position: GPSPosition | None = None
+_external_lock = threading.Lock()
+
+
+def set_external_position(position: GPSPosition) -> None:
+    """Register a GPS position from a non-gpsd source."""
+    global _external_position
+    with _external_lock:
+        _external_position = position
+
+
+def get_external_position() -> GPSPosition | None:
+    """Return the most recently registered non-gpsd position, if any."""
+    with _external_lock:
+        return _external_position
+
 
 def get_gps_reader() -> GPSDClient | None:
     """Get the global GPS client instance."""
@@ -510,11 +529,12 @@ def stop_gps() -> None:
 
 
 def get_current_position() -> GPSPosition | None:
-    """Get the current GPS position from the global client."""
+    """Get the current GPS position from the global client, falling back to
+    an externally-registered position (e.g. Meshtastic) when gpsd has none."""
     client = get_gps_reader()
-    if client:
+    if client and client.position:
         return client.position
-    return None
+    return get_external_position()
 
 
 # ============================================

--- a/utils/meshtastic.py
+++ b/utils/meshtastic.py
@@ -598,6 +598,11 @@ class MeshtasticClient:
         except Exception as e:
             logger.error(f"Error processing Meshtastic packet: {e}")
 
+    def _is_local_node(self, node_num: int) -> bool:
+        my_info = getattr(self._interface, "myInfo", None)
+        my_num = getattr(my_info, "my_node_num", None)
+        return my_num is not None and node_num == my_num
+
     def _track_node_from_packet(self, packet: dict, decoded: dict, portnum: str) -> None:
         """Update node tracking from received packet."""
         from_num = packet.get("from", 0)
@@ -647,6 +652,42 @@ class MeshtasticClient:
                     node.latitude = lat
                     node.longitude = lon
                     node.altitude = position.get("altitude", node.altitude)
+
+                    try:
+                        from utils.event_pipeline import process_event
+
+                        process_event(
+                            "meshtastic",
+                            {
+                                "id": node.user_id,
+                                "callsign": node.long_name or node.short_name,
+                                "lat": node.latitude,
+                                "lon": node.longitude,
+                                "altitude": node.altitude,
+                            },
+                            "position",
+                        )
+                    except Exception:
+                        # Event pipeline failures should never break mesh packet handling
+                        pass
+
+                    if self._is_local_node(from_num):
+                        try:
+                            from utils.gps import GPSPosition, set_external_position
+
+                            set_external_position(
+                                GPSPosition(
+                                    latitude=node.latitude,
+                                    longitude=node.longitude,
+                                    altitude=node.altitude,
+                                    fix_quality=3,
+                                    timestamp=now,
+                                    device=f"meshtastic:{node.user_id}",
+                                )
+                            )
+                        except Exception:
+                            # GPS forwarding failures should never break mesh packet handling
+                            pass
 
         # Parse TELEMETRY_APP for battery and other metrics
         elif portnum == "TELEMETRY_APP":

--- a/utils/meshtastic.py
+++ b/utils/meshtastic.py
@@ -127,6 +127,7 @@ class MeshNode:
     latitude: float | None = None
     longitude: float | None = None
     altitude: int | None = None
+    sats_in_view: int | None = None
     battery_level: int | None = None
     snr: float | None = None
     last_heard: datetime | None = None
@@ -149,6 +150,7 @@ class MeshNode:
             "latitude": self.latitude,
             "longitude": self.longitude,
             "altitude": self.altitude,
+            "sats_in_view": self.sats_in_view,
             "battery_level": self.battery_level,
             "snr": self.snr,
             "last_heard": self.last_heard.isoformat() if self.last_heard else None,
@@ -176,6 +178,7 @@ class NodeInfo:
     latitude: float | None
     longitude: float | None
     altitude: int | None
+    sats_in_view: int | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -188,6 +191,7 @@ class NodeInfo:
                 "latitude": self.latitude,
                 "longitude": self.longitude,
                 "altitude": self.altitude,
+                "sats_in_view": self.sats_in_view,
             }
             if self.latitude is not None
             else None,
@@ -652,6 +656,7 @@ class MeshtasticClient:
                     node.latitude = lat
                     node.longitude = lon
                     node.altitude = position.get("altitude", node.altitude)
+                    node.sats_in_view = position.get("satsInView", node.sats_in_view)
 
                     try:
                         from utils.event_pipeline import process_event
@@ -809,6 +814,7 @@ class MeshtasticClient:
                 latitude=position.get("latitude"),
                 longitude=position.get("longitude"),
                 altitude=position.get("altitude"),
+                sats_in_view=position.get("satsInView"),
             )
         except Exception as e:
             logger.error(f"Error getting node info: {e}")
@@ -870,6 +876,7 @@ class MeshtasticClient:
                         node.latitude = lat
                         node.longitude = lon
                         node.altitude = position.get("altitude", node.altitude)
+                        node.sats_in_view = position.get("satsInView", node.sats_in_view)
 
                 # Update last heard from SDK
                 last_heard = node_data.get("lastHeard")


### PR DESCRIPTION
## Summary
- When a connected Meshtastic node reports a GPS position, feed it into INTERCEPT's observer-location fallback chain (`utils/gps.py`) so modes that need an observer location (pass prediction, mapping) can use a Meshtastic node's GPS as a source, same as any other GPS input.
- Also forward Meshtastic position updates through the existing event pipeline (`utils/event_pipeline.py`) so they participate in whatever else consumes positional events.
- Surface `Position.sats_in_view` (already sent by Meshtastic devices, previously unparsed) as a SATS stat in the Meshtastic mode's status strip and in each node's map popup — useful for confirming a device (e.g. Heltec T114) actually has a GPS fix at a glance, without needing the device's own screen.

## Why
Built this running INTERCEPT against a Heltec T114 as a mobile Meshtastic node alongside RTL-SDR ADS-B/SIGINT capture on a Raspberry Pi. The T114 already has a good GPS fix by the time other modes start — piping that into the observer-location chain means pass prediction etc. don't need a second GPS source, and the satellite count makes it obvious from the dashboard whether the device has acquired a fix.

## Test plan
- [x] `pytest tests/test_meshtastic.py tests/test_gps.py` — 41 passed
- [x] `ruff check` on all changed Python files — clean
- [x] Verified live against real hardware (Heltec T114, USB serial): node connects, `node_info` populates correctly, `sats_in_view` flows through to the API and the UI once a GPS fix is present