### PR TITLE
feat(unraid): add Community Applications template and setup wizard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,13 @@ INTERCEPT_SHARED_OBSERVER_LOCATION=true
 # INTERCEPT_DEFAULT_LAT=40.7128
 # INTERCEPT_DEFAULT_LON=-74.0060
 
+# Unraid / Docker install (set by the Community Applications template)
+# INTERCEPT_UNRAID=true
+# INTERCEPT_DOCKER=true
+# INTERCEPT_INSTANCE_DIR=/app/instance
+# INTERCEPT_ENV_FILE=/config/.env
+# INTERCEPT_SQLITE_JOURNAL=DELETE
+
 # =============================================================================
 # AGENT SETTINGS (for docker-compose.agent.yml on remote Pis)
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to iNTERCEPT will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Unraid app + setup wizard** — Community Applications template in `unraid/intercept.xml`, persistent `instance/` and `/config` volumes, FUSE-safe SQLite journal mode on Unraid user shares, and a first-run wizard that reports USB passthrough via `GET /setup/status`.
+
+---
+
 ## [2.32.0] - 2026-07-07
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -292,7 +292,7 @@ COPY . .
 RUN find . -name '*.sh' -exec sed -i 's/\r$//' {} +
 
 # Create data directory for persistence
-RUN mkdir -p /app/data /app/data/weather_sat /app/data/radiosonde/logs
+RUN mkdir -p /app/data /app/data/weather_sat /app/data/radiosonde/logs /app/instance /config
 
 # Expose web interface port
 EXPOSE 5050
@@ -302,6 +302,7 @@ EXPOSE 5443
 ENV INTERCEPT_HOST=0.0.0.0 \
     INTERCEPT_PORT=5050 \
     INTERCEPT_LOG_LEVEL=INFO \
+    INTERCEPT_INSTANCE_DIR=/app/instance \
     PYTHONUNBUFFERED=1
 
 # Health check using the new endpoint

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ docker compose --profile basic up -d --build
 
 > **Note:** Docker requires privileged mode for USB SDR access. SDR devices are passed through via `/dev/bus/usb`.
 
+### Unraid
+
+Install INTERCEPT as a Community Applications Docker app, then finish setup in the browser wizard.
+
+1. Load `unraid/intercept.xml` (Docker → Add Container → Advanced View), or add the raw template URL from that file.
+2. Set a real admin password. Keep privileged mode and `/dev/bus/usb`.
+3. Map the SQLite directory to a **cache/pool** path (`/mnt/cache/appdata/intercept/instance`). Unraid user shares (`/mnt/user`) are FUSE; INTERCEPT falls back to DELETE journal mode there.
+4. Open `http://TOWER:5050/`, sign in, and complete Quick Setup. After login, `GET /setup/status` reports USB passthrough, storage journal mode, and whether setup is complete.
+
+Full steps: [unraid/README.md](unraid/README.md).
+
 For multi-architecture builds (amd64 + arm64 for Raspberry Pi), see `build-multiarch.sh` — it handles cross-compilation and registry push in one step.
 
 ### Environment Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       # Persist runtime output directories across container rebuilds.
       # Mount subdirectories individually so Python modules in /app/data are not shadowed.
+      - ./instance:/app/instance
       - ./data/weather_sat:/app/data/weather_sat
       - ./data/radiosonde:/app/data/radiosonde
       - ./data/subghz:/app/data/subghz
@@ -39,6 +40,7 @@ services:
       - INTERCEPT_HOST=0.0.0.0
       - INTERCEPT_PORT=5050
       - INTERCEPT_LOG_LEVEL=INFO
+      - INTERCEPT_INSTANCE_DIR=/app/instance
       # HTTPS support (auto-generates self-signed cert)
       # - INTERCEPT_HTTPS=true
       # - INTERCEPT_PORT=5443
@@ -89,6 +91,7 @@ services:
     devices:
       - /dev/bus/usb:/dev/bus/usb
     volumes:
+      - ./instance:/app/instance
       - ./data/weather_sat:/app/data/weather_sat
       - ./data/radiosonde:/app/data/radiosonde
       - ./data/subghz:/app/data/subghz
@@ -98,6 +101,7 @@ services:
       - INTERCEPT_HOST=0.0.0.0
       - INTERCEPT_PORT=5050
       - INTERCEPT_LOG_LEVEL=INFO
+      - INTERCEPT_INSTANCE_DIR=/app/instance
       # HTTPS support (auto-generates self-signed cert)
       # - INTERCEPT_HTTPS=true
       # - INTERCEPT_PORT=5443

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -36,6 +36,7 @@ def register_blueprints(app):
     from .satellite import satellite_bp
     from .sensor import sensor_bp
     from .settings import settings_bp
+    from .setup import setup_bp
     from .signalid import signalid_bp
     from .space_weather import space_weather_bp
     from .spy_stations import spy_stations_bp
@@ -68,6 +69,7 @@ def register_blueprints(app):
     app.register_blueprint(satellite_bp)
     app.register_blueprint(gps_bp)
     app.register_blueprint(settings_bp)
+    app.register_blueprint(setup_bp)
     app.register_blueprint(correlation_bp)
     app.register_blueprint(receiver_bp)
     app.register_blueprint(meshtastic_bp)

--- a/routes/settings.py
+++ b/routes/settings.py
@@ -30,7 +30,10 @@ _env_lock = threading.Lock()
 
 
 def _get_env_file_path() -> Path:
-    """Return the project .env path."""
+    """Return the project .env path (INTERCEPT_ENV_FILE on Unraid)."""
+    override = os.environ.get("INTERCEPT_ENV_FILE", "").strip()
+    if override:
+        return Path(override)
     return Path(__file__).resolve().parent.parent / ".env"
 
 

--- a/routes/setup.py
+++ b/routes/setup.py
@@ -1,0 +1,109 @@
+"""First-run / Unraid installation wizard API."""
+
+from __future__ import annotations
+
+from flask import Blueprint, Response
+
+from utils.database import get_setting, set_setting
+from utils.logging import get_logger
+from utils.responses import api_error, api_success
+from utils.unraid import (
+    running_in_docker,
+    running_on_unraid,
+    storage_advice,
+    usb_passthrough_present,
+)
+
+logger = get_logger("intercept.setup")
+
+setup_bp = Blueprint("setup", __name__, url_prefix="/setup")
+
+SETUP_COMPLETE_KEY = "setup.complete.v1"
+
+
+def _observer_configured() -> tuple[bool, float, float]:
+    try:
+        from config import DEFAULT_LATITUDE, DEFAULT_LONGITUDE
+    except Exception:
+        return False, 0.0, 0.0
+    configured = DEFAULT_LATITUDE != 0.0 or DEFAULT_LONGITUDE != 0.0
+    return configured, float(DEFAULT_LATITUDE), float(DEFAULT_LONGITUDE)
+
+
+def _cached_sdr_summary() -> list[dict[str, object]]:
+    try:
+        from utils.sdr.detection import get_cached_devices
+    except Exception:
+        return []
+    devices = get_cached_devices()
+    if not devices:
+        return []
+    summary: list[dict[str, object]] = []
+    for device in devices:
+        sdr_type = device.sdr_type.value if hasattr(device.sdr_type, "value") else str(device.sdr_type)
+        summary.append(
+            {
+                "type": sdr_type,
+                "index": device.index,
+                "name": device.name,
+                "serial": device.serial or "",
+            }
+        )
+    return summary
+
+
+def build_setup_status() -> dict[str, object]:
+    """Return wizard state without probing USB hardware."""
+    from utils.database import get_instance_dir
+
+    complete = bool(get_setting(SETUP_COMPLETE_KEY, False))
+    observer_ok, lat, lon = _observer_configured()
+    instance_dir = get_instance_dir()
+    try:
+        from config import ADMIN_PASSWORD, ADMIN_USERNAME
+    except Exception:
+        admin_username, default_admin = "admin", True
+    else:
+        admin_username = ADMIN_USERNAME
+        default_admin = ADMIN_PASSWORD == "admin"
+
+    return {
+        "complete": complete,
+        "platform": {
+            "unraid": running_on_unraid(),
+            "docker": running_in_docker(),
+            "usb_passthrough": usb_passthrough_present(),
+        },
+        "storage": storage_advice(instance_dir),
+        "observer": {
+            "configured": observer_ok,
+            "lat": lat,
+            "lon": lon,
+        },
+        "admin": {
+            "username": admin_username,
+            "using_default_password": default_admin,
+        },
+        "sdr_devices": _cached_sdr_summary(),
+    }
+
+
+@setup_bp.route("/status", methods=["GET"])
+def setup_status() -> Response:
+    """Current first-run / Unraid wizard status."""
+    try:
+        return api_success(data=build_setup_status())
+    except Exception as exc:
+        logger.error("Error building setup status: %s", exc)
+        return api_error(str(exc), 500)
+
+
+@setup_bp.route("/complete", methods=["POST"])
+def mark_setup_complete() -> Response:
+    """Persist setup completion in SQLite so it survives browser/localStorage."""
+    try:
+        set_setting(SETUP_COMPLETE_KEY, True)
+        return api_success(data={"complete": True}, message="Setup marked complete")
+    except Exception as exc:
+        logger.error("Error marking setup complete: %s", exc)
+        return api_error(str(exc), 500)

--- a/start.sh
+++ b/start.sh
@@ -21,7 +21,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ── Load .env if present ──────────────────────────────────────────────────────
 if [[ -f "$SCRIPT_DIR/.env" ]]; then
     set -a
+    # shellcheck disable=SC1091
     source "$SCRIPT_DIR/.env"
+    set +a
+fi
+if [[ -n "${INTERCEPT_ENV_FILE:-}" && -f "$INTERCEPT_ENV_FILE" && "$INTERCEPT_ENV_FILE" != "$SCRIPT_DIR/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$INTERCEPT_ENV_FILE"
     set +a
 fi
 

--- a/static/js/core/first-run-setup.js
+++ b/static/js/core/first-run-setup.js
@@ -11,16 +11,34 @@ const FirstRunSetup = (function() {
     let modeStatusEl = null;
     let modeSelectEl = null;
     let uiTierStatusEl = null;
+    let hardwareStatusEl = null;
+    let hardwareStepEl = null;
 
     let dependencyReady = null;
+    let serverStatus = null;
 
     function init() {
         buildDOM();
         maybeShow();
     }
 
-    function maybeShow() {
+    async function maybeShow() {
         if (localStorage.getItem(COMPLETE_KEY) === 'true') return;
+
+        try {
+            const response = await fetch('/setup/status');
+            if (response.ok) {
+                const payload = await response.json();
+                serverStatus = payload;
+                if (payload.complete) {
+                    localStorage.setItem(COMPLETE_KEY, 'true');
+                    return;
+                }
+                applyServerHints(payload);
+            }
+        } catch (_err) {
+            serverStatus = null;
+        }
 
         if (localStorage.getItem('disclaimerAccepted') === 'true') {
             open();
@@ -96,6 +114,16 @@ const FirstRunSetup = (function() {
                 actionsEl.appendChild(openToolsBtn);
             }
         );
+
+        hardwareStepEl = createStep(
+            'Unraid / USB SDR',
+            'Confirm USB passthrough so RTL-SDR and HackRF dongles appear in this container.',
+            (statusEl, actionsEl) => {
+                hardwareStatusEl = statusEl;
+                actionsEl.appendChild(buildButton('Recheck USB', refreshHardwareStatus));
+            }
+        );
+        hardwareStepEl.hidden = true;
 
         const locationStep = createStep(
             'Observer Location',
@@ -228,6 +256,7 @@ const FirstRunSetup = (function() {
         );
 
         content.appendChild(depsStep);
+        content.appendChild(hardwareStepEl);
         content.appendChild(locationStep);
         content.appendChild(notifyStep);
         content.appendChild(modeStep);
@@ -260,6 +289,56 @@ const FirstRunSetup = (function() {
 
         overlayEl.appendChild(modal);
         document.body.appendChild(overlayEl);
+    }
+
+    function applyServerHints(payload) {
+        if (!payload || typeof payload !== 'object') return;
+        const platform = payload.platform || {};
+        if (hardwareStepEl) {
+            hardwareStepEl.hidden = !(platform.unraid || platform.docker);
+        }
+        const observer = payload.observer || {};
+        if (observer.configured && observer.lat != null && observer.lon != null) {
+            if (!localStorage.getItem('observerLat')) {
+                localStorage.setItem('observerLat', String(observer.lat));
+            }
+            if (!localStorage.getItem('observerLon')) {
+                localStorage.setItem('observerLon', String(observer.lon));
+            }
+        }
+        refreshHardwareStatus();
+    }
+
+    async function refreshHardwareStatus() {
+        if (!hardwareStatusEl) return;
+        hardwareStatusEl.textContent = 'Checking...';
+        let status = serverStatus;
+        try {
+            const response = await fetch('/setup/status');
+            if (response.ok) {
+                status = await response.json();
+                serverStatus = status;
+            }
+        } catch (_err) {
+            /* keep last known status */
+        }
+        const platform = (status && status.platform) || {};
+        const usb = Boolean(platform.usb_passthrough);
+        const devices = (status && status.sdr_devices) || [];
+        const fuse = Boolean(status && status.storage && status.storage.fuse_or_network);
+        let label = usb ? 'USB bus mapped' : 'USB bus not visible';
+        if (usb && devices.length) {
+            label = `${devices.length} SDR device(s) cached`;
+        } else if (usb) {
+            label = 'USB mapped — plug in a dongle and open Devices';
+        }
+        if (fuse) {
+            label += ' · use cache disk for instance/';
+        }
+        setStatus(hardwareStatusEl, usb, label);
+        if (hardwareStepEl) {
+            hardwareStepEl.hidden = !(platform.unraid || platform.docker);
+        }
     }
 
     function createStep(title, description, initActions) {
@@ -338,6 +417,15 @@ const FirstRunSetup = (function() {
         setStatus(modeStatusEl, hasDefaultMode, hasDefaultMode ? localStorage.getItem(DEFAULT_MODE_KEY) : 'Not set');
         const hasTier = Boolean(localStorage.getItem('intercept-ui-tier'));
         setStatus(uiTierStatusEl, hasTier, hasTier ? localStorage.getItem('intercept-ui-tier') : 'Not set');
+        if (hardwareStatusEl && hardwareStepEl && !hardwareStepEl.hidden) {
+            const platform = (serverStatus && serverStatus.platform) || {};
+            const usb = Boolean(platform.usb_passthrough);
+            setStatus(
+                hardwareStatusEl,
+                usb,
+                usb ? 'USB bus mapped' : 'USB bus not visible'
+            );
+        }
 
         if (dependencyReady === null) {
             checkDependencies();
@@ -405,8 +493,17 @@ const FirstRunSetup = (function() {
         refreshStatuses();
     }
 
-    function completeSetup() {
+    async function completeSetup() {
         localStorage.setItem(COMPLETE_KEY, 'true');
+        try {
+            await fetch('/setup/complete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: '{}',
+            });
+        } catch (_err) {
+            /* local completion still stands */
+        }
         close();
 
         if (typeof showAppToast === 'function') {

--- a/tests/test_unraid.py
+++ b/tests/test_unraid.py
@@ -1,0 +1,140 @@
+"""Unraid Community Applications template and first-run wizard."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestUnraidTemplate:
+    def _root(self) -> ET.Element:
+        path = ROOT / "unraid" / "intercept.xml"
+        assert path.is_file()
+        tree = ET.parse(path)
+        return tree.getroot()
+
+    def test_template_is_installable(self):
+        root = self._root()
+        assert root.tag == "Container"
+        assert root.attrib.get("version") == "2"
+        assert root.findtext("Name") == "INTERCEPT"
+        assert root.findtext("Repository") == "ghcr.io/smittix/intercept:latest"
+        assert root.findtext("Network") == "bridge"
+        assert root.findtext("Privileged") == "true"
+        assert "[PORT:5050]" in (root.findtext("WebUI") or "")
+        assert "FUSE" in (root.findtext("Requires") or "")
+
+    def test_template_maps_persistent_paths_and_usb(self):
+        root = self._root()
+        configs = {item.attrib.get("Target"): item for item in root.findall("Config")}
+        assert configs["5050"].attrib.get("Type") == "Port"
+        assert configs["/app/instance"].attrib.get("Default") == "/mnt/cache/appdata/intercept/instance"
+        assert configs["/app/data"].attrib.get("Default") == "/mnt/user/appdata/intercept/data"
+        assert configs["/config"].attrib.get("Default") == "/mnt/user/appdata/intercept/config"
+        assert configs[""].attrib.get("Type") == "Device"
+        assert configs[""].attrib.get("Default") == "/dev/bus/usb"
+        assert (configs[""].text or "").strip() == "/dev/bus/usb"
+        assert configs["INTERCEPT_ADMIN_PASSWORD"].attrib.get("Mask") == "true"
+        assert configs["INTERCEPT_UNRAID"].attrib.get("Default") == "true"
+        assert configs["INTERCEPT_ENV_FILE"].attrib.get("Default") == "/config/.env"
+        assert configs["INTERCEPT_INSTANCE_DIR"].attrib.get("Default") == "/app/instance"
+
+
+class TestUnraidHelpers:
+    def test_env_flags_detect_unraid_and_docker(self, tmp_path, monkeypatch):
+        from utils.unraid import running_in_docker, running_on_unraid
+
+        monkeypatch.delenv("INTERCEPT_UNRAID", raising=False)
+        monkeypatch.delenv("INTERCEPT_DOCKER", raising=False)
+        with patch("utils.unraid._UNRAID_MARKERS", (tmp_path / "missing",)):
+            assert running_on_unraid() is False
+        monkeypatch.setenv("INTERCEPT_UNRAID", "true")
+        assert running_on_unraid() is True
+        monkeypatch.setenv("INTERCEPT_DOCKER", "1")
+        assert running_in_docker() is True
+
+    def test_fuse_paths_use_delete_journal(self, tmp_path, monkeypatch):
+        from utils.unraid import recommended_sqlite_journal_mode
+
+        db_path = tmp_path / "intercept.db"
+        db_path.write_text("", encoding="utf-8")
+        monkeypatch.delenv("INTERCEPT_SQLITE_JOURNAL", raising=False)
+        with patch("utils.unraid.filesystem_type", return_value="fuse.shfs"):
+            assert recommended_sqlite_journal_mode(db_path) == "DELETE"
+        with patch("utils.unraid.filesystem_type", return_value="ext4"):
+            assert recommended_sqlite_journal_mode(db_path) == "WAL"
+        monkeypatch.setenv("INTERCEPT_SQLITE_JOURNAL", "DELETE")
+        with patch("utils.unraid.filesystem_type", return_value="ext4"):
+            assert recommended_sqlite_journal_mode(db_path) == "DELETE"
+
+    def test_filesystem_type_picks_longest_mount(self, tmp_path, monkeypatch):
+        from utils import unraid as unraid_mod
+
+        mount_file = tmp_path / "mounts"
+        target = tmp_path / "appdata" / "instance"
+        target.mkdir(parents=True)
+        mount_file.write_text(
+            "rootfs / rootfs rw 0 0\n"
+            f"/dev/md1 {tmp_path / 'appdata'} fuse.shfs rw 0 0\n",
+            encoding="utf-8",
+        )
+        real_path = Path
+
+        def path_factory(value=".", *args, **kwargs):
+            if str(value) == "/proc/mounts":
+                return mount_file
+            return real_path(value, *args, **kwargs)
+
+        monkeypatch.setattr(unraid_mod, "Path", path_factory)
+        assert unraid_mod.filesystem_type(target / "intercept.db") == "fuse.shfs"
+
+    def test_instance_dir_env_override(self, tmp_path, monkeypatch):
+        from utils import database as db
+
+        monkeypatch.setenv("INTERCEPT_INSTANCE_DIR", str(tmp_path))
+        assert db.get_instance_dir() == tmp_path
+        assert db.get_db_path() == tmp_path / "intercept.db"
+
+
+class TestSetupWizardRoutes:
+    def test_status_and_complete(self, client, monkeypatch):
+        monkeypatch.setenv("INTERCEPT_UNRAID", "true")
+        monkeypatch.setenv("INTERCEPT_DOCKER", "true")
+        with patch("routes.setup.usb_passthrough_present", return_value=True), patch(
+            "routes.setup.get_setting", return_value=False
+        ), patch("routes.setup.set_setting") as mock_set:
+            status = client.get("/setup/status")
+            assert status.status_code == 200
+            payload = status.get_json()
+            assert payload["status"] == "success"
+            assert payload["platform"]["unraid"] is True
+            assert payload["platform"]["docker"] is True
+            assert payload["platform"]["usb_passthrough"] is True
+            assert payload["complete"] is False
+            assert "journal_mode" in payload["storage"]
+
+            done = client.post("/setup/complete")
+            assert done.status_code == 200
+            assert done.get_json()["complete"] is True
+            mock_set.assert_called()
+
+
+class TestPackagingDocs:
+    def test_compose_and_image_persist_instance(self):
+        compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        start = (ROOT / "start.sh").read_text(encoding="utf-8")
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        assert "./instance:/app/instance" in compose
+        assert "INTERCEPT_INSTANCE_DIR=/app/instance" in compose
+        assert "INTERCEPT_INSTANCE_DIR=/app/instance" in dockerfile
+        assert "INTERCEPT_ENV_FILE" in start
+        assert "unraid/intercept.xml" in readme
+        assert "/setup/status" in readme
+        wizard = (ROOT / "static" / "js" / "core" / "first-run-setup.js").read_text(encoding="utf-8")
+        assert "/setup/status" in wizard
+        assert "/setup/complete" in wizard
+        assert "Unraid / USB SDR" in wizard

--- a/unraid/README.md
+++ b/unraid/README.md
@@ -1,0 +1,54 @@
+# INTERCEPT on Unraid
+
+Install INTERCEPT as a Docker app, then finish setup in the browser wizard.
+
+## Community Applications (app)
+
+1. Install the **Community Applications** plugin if it is not already present.
+2. Add this template repository (or load the XML by hand):
+
+   `https://raw.githubusercontent.com/smittix/intercept/main/unraid/intercept.xml`
+
+3. In **Docker → Add Container**, switch to Advanced View and load `unraid/intercept.xml`, or search for **INTERCEPT** once the template is published.
+4. Set a real **Admin password**. Leave privileged mode and `/dev/bus/usb` enabled so SDR dongles work.
+5. Prefer a **cache/pool** path for the application database:
+
+   `/mnt/cache/appdata/intercept/instance`
+
+   Unraid `/mnt/user/...` paths are FUSE (shfs). INTERCEPT detects that and falls back from SQLite WAL to DELETE journal mode, which is safe but slower.
+6. Apply, wait for the health check, then open `http://TOWER:5050/`.
+7. Sign in and complete **Quick Setup**: USB/SDR check, observer location, default mode, display mode.
+
+The published image is `ghcr.io/smittix/intercept:latest`. If that tag is not available yet, build locally on the Unraid box:
+
+```bash
+git clone https://github.com/smittix/intercept.git /mnt/user/appdata/intercept/src
+cd /mnt/user/appdata/intercept/src
+docker build -t ghcr.io/smittix/intercept:latest .
+```
+
+Then start the template against the local tag.
+
+## Persistent layout
+
+| Host path | Container | Contents |
+|-----------|-----------|----------|
+| `/mnt/cache/appdata/intercept/instance` | `/app/instance` | SQLite (`intercept.db`), TLE cache |
+| `/mnt/user/appdata/intercept/data` | `/app/data` | Weather-sat, radiosonde, Sub-GHz, ADS-B files |
+| `/mnt/user/appdata/intercept/config` | `/config` | Wizard-written `.env` |
+
+Back up `instance/` and `config/`. Capture files in `data/` can be large.
+
+## USB SDR notes
+
+- Privileged mode is required so `rtl_test`, `hackrf_info`, and SoapySDR can open the dongle.
+- Bind `/dev/bus/usb`. After plugging in a new dongle, restart the container.
+- If the kernel claims an RTL-SDR as a DVB tuner, blacklist those modules on the Unraid host (see `docs/HARDWARE.md`).
+- WiFi monitor-mode scanning needs host networking and is not the default. Use a dedicated Linux install or host-network compose for that mode.
+
+## Health
+
+- Liveness: `GET /health`
+- Wizard status (after login): `GET /setup/status`
+
+Do not publish port 5050 to the public Internet. Keep the WebUI on the LAN or behind a VPN.

--- a/unraid/intercept.xml
+++ b/unraid/intercept.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>INTERCEPT</Name>
+  <Repository>ghcr.io/smittix/intercept:latest</Repository>
+  <Registry>https://github.com/smittix/intercept/pkgs/container/intercept</Registry>
+  <TemplateURL>https://raw.githubusercontent.com/smittix/intercept/main/unraid/intercept.xml</TemplateURL>
+  <Network>bridge</Network>
+  <Privileged>true</Privileged>
+  <Shell>bash</Shell>
+  <Support>https://github.com/smittix/intercept/issues</Support>
+  <Project>https://github.com/smittix/intercept</Project>
+  <Overview>INTERCEPT is a web-based Signal Intelligence platform for software-defined radio. After first start, sign in and complete the on-screen setup wizard (observer location, USB SDR check, default mode). Privileged mode and USB passthrough are required for RTL-SDR, HackRF, and similar dongles. Do not expose this container to the Internet.</Overview>
+  <Category>Tools: Network:Other Productivity:Other</Category>
+  <WebUI>http://[IP]:[PORT:5050]/</WebUI>
+  <Icon>https://raw.githubusercontent.com/smittix/intercept/main/static/images/globe/satellite-icon.svg</Icon>
+  <ExtraParams>--restart unless-stopped</ExtraParams>
+  <Requires>Unraid with Docker enabled, a USB controller for SDR dongles, and enough RAM for decoder processes. Map instance storage to a cache/pool disk when possible — Unraid user shares (/mnt/user) are FUSE and are a poor fit for SQLite WAL.</Requires>
+  <Config Name="WebUI" Target="5050" Default="5050" Mode="tcp" Description="INTERCEPT web interface. Do not port-forward this to the Internet." Type="Port" Display="always" Required="true" Mask="false"/>
+  <Config Name="USB devices" Target="" Default="/dev/bus/usb" Mode="" Description="Host USB bus so RTL-SDR, HackRF, and similar dongles appear inside the container." Type="Device" Display="always" Required="true" Mask="false">/dev/bus/usb</Config>
+  <Config Name="Application database" Target="/app/instance" Default="/mnt/cache/appdata/intercept/instance" Mode="rw" Description="SQLite settings, users, and TLE cache. Prefer a cache/pool path, not /mnt/user." Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Capture data" Target="/app/data" Default="/mnt/user/appdata/intercept/data" Mode="rw" Description="Weather-sat, radiosonde, Sub-GHz, and ADS-B capture files." Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Environment file" Target="/config" Default="/mnt/user/appdata/intercept/config" Mode="rw" Description="Persisted .env written by the setup wizard (observer location and other INTERCEPT_* keys)." Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Timezone" Target="TZ" Default="UTC" Mode="" Description="IANA timezone, for example America/Chicago." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Admin username" Target="INTERCEPT_ADMIN_USERNAME" Default="admin" Mode="" Description="Web UI login name. Change the password below before first start." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Admin password" Target="INTERCEPT_ADMIN_PASSWORD" Default="" Mode="" Description="Web UI password. Required. Do not leave this as admin." Type="Variable" Display="always" Required="true" Mask="true"/>
+  <Config Name="Observer latitude" Target="INTERCEPT_DEFAULT_LAT" Default="0" Mode="" Description="Optional. Decimal degrees. The in-app wizard can also set this." Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="Observer longitude" Target="INTERCEPT_DEFAULT_LON" Default="0" Mode="" Description="Optional. Decimal degrees. The in-app wizard can also set this." Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="Log level" Target="INTERCEPT_LOG_LEVEL" Default="INFO" Mode="" Description="Python log level: DEBUG, INFO, WARNING, ERROR." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Bind address" Target="INTERCEPT_HOST" Default="0.0.0.0" Mode="" Description="Container listen address." Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
+  <Config Name="Listen port" Target="INTERCEPT_PORT" Default="5050" Mode="" Description="Container listen port. Keep in sync with the WebUI port mapping." Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
+  <Config Name="Instance directory" Target="INTERCEPT_INSTANCE_DIR" Default="/app/instance" Mode="" Description="SQLite directory inside the container." Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
+  <Config Name="Env file path" Target="INTERCEPT_ENV_FILE" Default="/config/.env" Mode="" Description="Wizard-managed environment file inside the config volume." Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
+  <Config Name="Unraid install" Target="INTERCEPT_UNRAID" Default="true" Mode="" Description="Marks this container as an Unraid Community Applications install so the setup wizard shows USB and storage guidance." Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
+  <Config Name="Docker install" Target="INTERCEPT_DOCKER" Default="true" Mode="" Description="Marks this process as containerized." Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
+  <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="Unraid nobody user ID. INTERCEPT still needs privileged USB access for SDR tools." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="Unraid users group ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+</Container>

--- a/utils/database.py
+++ b/utils/database.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import threading
 from contextlib import contextmanager
@@ -33,10 +34,37 @@ except ImportError:
 _local = _LocalClass()
 
 
+def get_instance_dir() -> Path:
+    """Return the SQLite directory, honoring INTERCEPT_INSTANCE_DIR."""
+    override = os.environ.get("INTERCEPT_INSTANCE_DIR", "").strip()
+    if override:
+        return Path(override)
+    return DB_DIR
+
+
 def get_db_path() -> Path:
     """Get the database file path, creating directory if needed."""
-    DB_DIR.mkdir(parents=True, exist_ok=True)
-    return DB_PATH
+    instance_dir = get_instance_dir()
+    instance_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        if instance_dir.resolve() == Path(DB_DIR).resolve():
+            return DB_PATH
+    except OSError:
+        if instance_dir == DB_DIR:
+            return DB_PATH
+    return instance_dir / "intercept.db"
+
+
+def _journal_mode_for(db_path: Path) -> str:
+    """WAL locally; DELETE on Unraid user shares and other FUSE/network mounts."""
+    allowed = {"DELETE", "WAL", "TRUNCATE", "MEMORY"}
+    try:
+        from utils.unraid import recommended_sqlite_journal_mode
+
+        mode = recommended_sqlite_journal_mode(db_path)
+    except Exception:
+        return "WAL"
+    return mode if mode in allowed else "WAL"
 
 
 def get_connection() -> sqlite3.Connection:
@@ -48,13 +76,13 @@ def get_connection() -> sqlite3.Connection:
             _local.connection.row_factory = sqlite3.Row
             # Enable foreign keys
             _local.connection.execute("PRAGMA foreign_keys = ON")
-            # Use WAL mode for better concurrent read/write performance
-            _local.connection.execute("PRAGMA journal_mode = WAL")
+            journal_mode = _journal_mode_for(db_path)
+            _local.connection.execute(f"PRAGMA journal_mode = {journal_mode}")
         except sqlite3.OperationalError as e:
             logger.error(
                 f"Cannot open database at {db_path}: {e}. "
                 f"If the file is owned by root, fix with: "
-                f"sudo chown -R $(whoami) {DB_DIR}"
+                f"sudo chown -R $(whoami) {get_instance_dir()}"
             )
             raise
     return _local.connection

--- a/utils/tle_store.py
+++ b/utils/tle_store.py
@@ -9,6 +9,7 @@ persisted by rewriting data/satellites.py at runtime),
 utils/weather_sat_predict._tle_cache, and the agent's own download.
 """
 
+import os
 import sqlite3
 import threading
 from pathlib import Path
@@ -17,15 +18,32 @@ from utils.logging import get_logger
 
 logger = get_logger("intercept.tle_store")
 
-_DB_PATH = Path(__file__).resolve().parent.parent / "instance" / "tle.db"
+_DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent / "instance" / "tle.db"
+_DB_PATH = _DEFAULT_DB_PATH
 _lock = threading.Lock()
 _cache: dict[str, tuple[str, str, str]] | None = None
 
 
+def _tle_db_path() -> Path:
+    override = os.environ.get("INTERCEPT_INSTANCE_DIR", "").strip()
+    if override:
+        return Path(override) / "tle.db"
+    return _DB_PATH
+
+
 def _connect() -> sqlite3.Connection:
-    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False, timeout=5)
-    conn.execute("PRAGMA journal_mode = WAL")
+    db_path = _tle_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path), check_same_thread=False, timeout=5)
+    try:
+        from utils.unraid import recommended_sqlite_journal_mode
+
+        journal = recommended_sqlite_journal_mode(db_path)
+    except Exception:
+        journal = "WAL"
+    if journal not in {"DELETE", "WAL", "TRUNCATE", "MEMORY"}:
+        journal = "WAL"
+    conn.execute(f"PRAGMA journal_mode = {journal}")
     conn.execute("PRAGMA busy_timeout = 5000")
     conn.execute(
         """

--- a/utils/unraid.py
+++ b/utils/unraid.py
@@ -1,0 +1,116 @@
+"""Unraid / NAS install helpers.
+
+Unraid user-share paths (`/mnt/user/...`) are FUSE (shfs). SQLite WAL
+needs a real POSIX filesystem for shared-memory files; FUSE, NFS, and
+CIFS mounts should use DELETE journal mode instead.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_UNRAID_TRUE = {"1", "true", "yes", "on"}
+_FUSE_HINTS = ("fuse", "shfs", "mergerfs", "nfs", "cifs", "smb")
+_UNRAID_MARKERS = (
+    Path("/etc/unraid-version"),
+    Path("/usr/local/emhttp/plugins/dynamix"),
+    Path("/boot/config/docker.cfg"),
+)
+
+
+def env_flag(name: str) -> bool:
+    """Return True when an env var is a conventional truthy flag."""
+    return os.environ.get(name, "").strip().lower() in _UNRAID_TRUE
+
+
+def running_in_docker() -> bool:
+    """Best-effort container detection."""
+    if env_flag("INTERCEPT_DOCKER"):
+        return True
+    if Path("/.dockerenv").exists():
+        return True
+    cgroup = Path("/proc/1/cgroup")
+    if cgroup.is_file():
+        try:
+            text = cgroup.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return False
+        return "docker" in text or "containerd" in text
+    return False
+
+
+def running_on_unraid() -> bool:
+    """True when the Unraid template set the flag or host markers exist."""
+    if env_flag("INTERCEPT_UNRAID"):
+        return True
+    return any(path.exists() for path in _UNRAID_MARKERS)
+
+
+def usb_passthrough_present() -> bool:
+    """True when the container can see a USB device tree (SDR dongles)."""
+    return Path("/dev/bus/usb").is_dir()
+
+
+def filesystem_type(path: Path) -> str:
+    """Return the mount fstype that covers *path*, or empty string."""
+    mounts = Path("/proc/mounts")
+    if not mounts.is_file():
+        return ""
+
+    try:
+        resolved = path.resolve()
+        lines = mounts.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
+        return ""
+
+    best_mount = ""
+    best_fstype = ""
+    for line in lines:
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        mount_point, fstype = parts[1], parts[2]
+        try:
+            decoded = mount_point.encode("utf-8").decode("unicode_escape")
+        except UnicodeError:
+            decoded = mount_point
+        candidate = Path(decoded)
+        try:
+            if resolved == candidate or candidate in resolved.parents:
+                mount_text = str(candidate)
+                if len(mount_text) >= len(best_mount):
+                    best_mount = mount_text
+                    best_fstype = fstype
+        except (OSError, ValueError):
+            continue
+    return best_fstype
+
+
+def is_network_or_fuse_filesystem(path: Path) -> bool:
+    """True when SQLite WAL is unsafe on this path."""
+    fstype = filesystem_type(path).lower()
+    return any(hint in fstype for hint in _FUSE_HINTS)
+
+
+def recommended_sqlite_journal_mode(path: Path) -> str:
+    """WAL on local disks; DELETE on Unraid user shares and network mounts."""
+    override = os.environ.get("INTERCEPT_SQLITE_JOURNAL", "").strip().upper()
+    if override in {"DELETE", "WAL", "TRUNCATE", "MEMORY"}:
+        return override
+    if is_network_or_fuse_filesystem(path):
+        return "DELETE"
+    return "WAL"
+
+
+def storage_advice(instance_dir: Path) -> dict[str, object]:
+    """Describe persistence and Unraid cache guidance for the setup wizard."""
+    journal = recommended_sqlite_journal_mode(instance_dir)
+    fuse = is_network_or_fuse_filesystem(instance_dir)
+    return {
+        "instance_dir": str(instance_dir),
+        "journal_mode": journal,
+        "fuse_or_network": fuse,
+        "prefer_cache_pool": fuse or running_on_unraid(),
+        "recommended_host_path": "/mnt/cache/appdata/intercept/instance",
+    }


### PR DESCRIPTION
## Summary
- Add an Unraid Community Applications template (`unraid/intercept.xml`) plus install docs.
- Persist SQLite and wizard `.env` via `INTERCEPT_INSTANCE_DIR` / `INTERCEPT_ENV_FILE`.
- Use DELETE journal mode on FUSE/Unraid user shares so SQLite does not corrupt.
- First-run wizard reports USB passthrough and stores completion in SQLite (`/setup/status`, `/setup/complete`).

## Test plan
- [x] `pytest tests/test_unraid.py tests/test_database.py tests/test_tle_store.py tests/test_routes.py tests/test_app.py` (75 passed)
- [ ] Load `unraid/intercept.xml` on an Unraid host and complete Quick Setup
- [ ] Confirm `/dev/bus/usb` appears and `/health` returns healthy
