### PR TITLE
Fix SDR hardware lockups, USB contention, and abrupt SIGKILL during process lifecycle

### DIFF
--- a/routes/listening_post/__init__.py
+++ b/routes/listening_post/__init__.py
@@ -472,28 +472,29 @@ def _stop_audio_stream_internal():
 
     had_processes = audio_process is not None or audio_rtl_process is not None
 
-    # Kill the pipeline processes and their groups
-    if audio_process:
+    def _stop_proc_group(proc):
+        if not proc:
+            return
         try:
-            # Kill entire process group (SDR demod + ffmpeg)
-            try:
-                os.killpg(os.getpgid(audio_process.pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                audio_process.kill()
-            audio_process.wait(timeout=0.5)
-        except Exception:
-            pass
-
-    if audio_rtl_process:
+            pgid = os.getpgid(proc.pid)
+            os.killpg(pgid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            with contextlib.suppress(Exception):
+                proc.terminate()
         try:
+            proc.wait(timeout=0.5)
+        except subprocess.TimeoutExpired:
             try:
-                os.killpg(os.getpgid(audio_rtl_process.pid), signal.SIGKILL)
+                pgid = os.getpgid(proc.pid)
+                os.killpg(pgid, signal.SIGKILL)
             except (ProcessLookupError, PermissionError):
-                audio_rtl_process.kill()
-            audio_rtl_process.wait(timeout=0.5)
-        except Exception:
-            pass
+                with contextlib.suppress(Exception):
+                    proc.kill()
+            with contextlib.suppress(Exception):
+                proc.wait(timeout=0.5)
 
+    _stop_proc_group(audio_process)
+    _stop_proc_group(audio_rtl_process)
     audio_process = None
     audio_rtl_process = None
 

--- a/routes/listening_post/audio.py
+++ b/routes/listening_post/audio.py
@@ -110,7 +110,7 @@ def start_audio() -> Response:
                 with contextlib.suppress(Exception):
                     scanner_proc_ref.kill()
         with contextlib.suppress(Exception):
-            subprocess.run(["pkill", "-9", "rtl_power"], capture_output=True, timeout=0.5)
+            subprocess.run(["pkill", "rtl_power"], capture_output=True, timeout=0.5)
         time.sleep(0.5)
 
     # Re-acquire lock for waterfall check and device claim

--- a/tests/test_sdr_detection.py
+++ b/tests/test_sdr_detection.py
@@ -18,13 +18,15 @@ def _clear_detection_caches():
 
 
 @patch("utils.sdr.detection.get_tool_path", return_value="/usr/bin/rtl_test")
-@patch("utils.sdr.detection.subprocess.run")
-def test_detect_rtlsdr_devices_filters_empty_serial_entries(mock_run, _mock_tool_path):
+@patch("utils.sdr.detection.subprocess.Popen")
+def test_detect_rtlsdr_devices_filters_empty_serial_entries(mock_popen, _mock_tool_path):
     """Ignore malformed rtl_test rows that have an empty SN field."""
-    mock_result = MagicMock()
-    mock_result.stdout = ""
-    mock_result.stderr = "Found 3 device(s):\n  0:  ??C?, , SN:\n  1:  ??C?, , SN:\n  2:  RTLSDRBlog, Blog V4, SN: 1\n"
-    mock_run.return_value = mock_result
+    mock_proc = MagicMock()
+    mock_proc.communicate.return_value = (
+        "",
+        "Found 3 device(s):\n  0:  ??C?, , SN:\n  1:  ??C?, , SN:\n  2:  RTLSDRBlog, Blog V4, SN: 1\n",
+    )
+    mock_popen.return_value = mock_proc
 
     devices = detect_rtlsdr_devices()
 
@@ -36,20 +38,40 @@ def test_detect_rtlsdr_devices_filters_empty_serial_entries(mock_run, _mock_tool
 
 
 @patch("utils.sdr.detection.get_tool_path", return_value="/usr/bin/rtl_test")
-@patch("utils.sdr.detection.subprocess.run")
-def test_detect_rtlsdr_devices_uses_replace_decode_mode(mock_run, _mock_tool_path):
+@patch("utils.sdr.detection.subprocess.Popen")
+def test_detect_rtlsdr_devices_uses_replace_decode_mode(mock_popen, _mock_tool_path):
     """Run rtl_test with tolerant decoding for malformed output bytes."""
-    mock_result = MagicMock()
-    mock_result.stdout = ""
-    mock_result.stderr = "Found 0 device(s):"
-    mock_run.return_value = mock_result
+    mock_proc = MagicMock()
+    mock_proc.communicate.return_value = ("", "Found 0 device(s):")
+    mock_popen.return_value = mock_proc
 
     detect_rtlsdr_devices()
 
-    _, kwargs = mock_run.call_args
+    _, kwargs = mock_popen.call_args
     assert kwargs["text"] is True
     assert kwargs["encoding"] == "utf-8"
     assert kwargs["errors"] == "replace"
+
+
+@patch("utils.sdr.detection.get_tool_path", return_value="/usr/bin/rtl_test")
+@patch("utils.sdr.detection.subprocess.Popen")
+def test_detect_rtlsdr_devices_timeout_graceful_recovery(mock_popen, _mock_tool_path):
+    """Gracefully catch timeout, terminate with SIGINT, and recover parsed devices."""
+    import subprocess
+
+    mock_proc = MagicMock()
+    # First communicate raises TimeoutExpired, second returns output captured so far
+    mock_proc.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd=["rtl_test"], timeout=5),
+        ("", "Found 1 device(s):\n  0:  Realtek, RTL2838UHIDIR, SN: 00000001\n"),
+    ]
+    mock_popen.return_value = mock_proc
+
+    devices = detect_rtlsdr_devices()
+
+    assert len(devices) == 1
+    assert devices[0].serial == "00000001"
+    assert mock_proc.send_signal.called
 
 
 # ---- HackRF detection tests ----

--- a/utils/process.py
+++ b/utils/process.py
@@ -160,7 +160,8 @@ def cleanup_stale_processes() -> None:
     processes_to_kill = ["rtl_adsb", "rtl_433", "multimon-ng", "rtl_fm"]
     for proc_name in processes_to_kill:
         with contextlib.suppress(subprocess.SubprocessError, OSError):
-            subprocess.run(["pkill", "-9", proc_name], capture_output=True)
+            # Use SIGTERM instead of SIGKILL (-9) to allow SDR hardware handles to close clean
+            subprocess.run(["pkill", proc_name], capture_output=True)
 
 
 _DUMP1090_PID_FILE = Path(__file__).resolve().parent.parent / "instance" / "dump1090.pid"

--- a/utils/sdr/detection.py
+++ b/utils/sdr/detection.py
@@ -52,9 +52,35 @@ def _is_sdr_in_use() -> bool:
         import sys
 
         app_mod = sys.modules.get("app")
-        if app_mod and hasattr(app_mod, "get_sdr_device_status"):
-            if app_mod.get_sdr_device_status():
+        if app_mod:
+            if hasattr(app_mod, "get_sdr_device_status") and app_mod.get_sdr_device_status():
                 return True
+            for attr in [
+                "sensor_process",
+                "current_process",
+                "adsb_process",
+                "rtlamr_process",
+                "ais_process",
+                "acars_process",
+                "vdl2_process",
+                "aprs_process",
+                "radiosonde_process",
+                "morse_process",
+            ]:
+                p = getattr(app_mod, attr, None)
+                if p is not None and (p.poll() is None if hasattr(p, "poll") else True):
+                    return True
+
+        # Check companion processes (e.g. rtl_tcp in rtlamr, audio streaming in listening post)
+        rtlamr_mod = sys.modules.get("routes.rtlamr")
+        if rtlamr_mod and getattr(rtlamr_mod, "rtl_tcp_process", None):
+            p = rtlamr_mod.rtl_tcp_process
+            if p is not None and p.poll() is None:
+                return True
+
+        lp_mod = sys.modules.get("routes.listening_post")
+        if lp_mod and getattr(lp_mod, "audio_running", False):
+            return True
     except Exception:
         pass
     return _hackrf_probe_blocked()
@@ -152,23 +178,25 @@ def detect_rtlsdr_devices() -> list[SDRDevice]:
             env=env,
         )
         try:
-            stdout, stderr = proc.communicate(timeout=5)
-        except subprocess.TimeoutExpired:
-            logger.warning("rtl_test timed out after 5s; stopping gracefully")
+            # rtl_test prints device list immediately on startup, then continues
+            # its tuner benchmark indefinitely. Give it 0.3s to emit the device
+            # list, then send SIGINT to cleanly exit without blocking or stalling USB.
+            time.sleep(0.3)
             with contextlib.suppress(OSError):
                 proc.send_signal(signal.SIGINT)
+            stdout, stderr = proc.communicate(timeout=1.0)
+            output = (stderr or "") + (stdout or "")
+        except subprocess.TimeoutExpired:
+            logger.warning("rtl_test timed out; stopping gracefully")
+            with contextlib.suppress(OSError):
+                proc.terminate()
             try:
-                stdout, stderr = proc.communicate(timeout=1.5)
+                stdout, stderr = proc.communicate(timeout=0.5)
             except subprocess.TimeoutExpired:
                 with contextlib.suppress(OSError):
-                    proc.terminate()
-                try:
-                    stdout, stderr = proc.communicate(timeout=0.5)
-                except subprocess.TimeoutExpired:
-                    with contextlib.suppress(OSError):
-                        proc.kill()
-                    stdout, stderr = proc.communicate()
-        output = (stderr or "") + (stdout or "")
+                    proc.kill()
+                stdout, stderr = proc.communicate()
+            output = (stderr or "") + (stdout or "")
 
         # Parse device info from rtl_test output
         # Format: "0:  Realtek, RTL2838UHIDIR, SN: 00000001"

--- a/utils/sdr/detection.py
+++ b/utils/sdr/detection.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import re
+import signal
 import subprocess
 import time
 
@@ -29,10 +30,10 @@ _HACKRF_CACHE_TTL_SECONDS = 3.0
 # both trigger it from DOMContentLoaded).  On a Pi the subprocess calls
 # (rtl_test, SoapySDRUtil, hackrf_info) each take seconds and block the
 # single gevent worker, serialising every other request behind them.
-# A short TTL cache avoids duplicate subprocess storms.
+# A cache avoids duplicate subprocess storms and prevents USB contention.
 _all_devices_cache: list[SDRDevice] = []
 _all_devices_cache_ts: float = 0.0
-_ALL_DEVICES_CACHE_TTL_SECONDS = 5.0
+_ALL_DEVICES_CACHE_TTL_SECONDS = 30.0
 
 
 def _hackrf_probe_blocked() -> bool:
@@ -43,6 +44,20 @@ def _hackrf_probe_blocked() -> bool:
         return get_subghz_manager().active_mode in {"rx", "decode", "tx", "sweep"}
     except Exception:
         return False
+
+
+def _is_sdr_in_use() -> bool:
+    """Return True when probing SDR devices would interfere with an active stream."""
+    try:
+        import sys
+
+        app_mod = sys.modules.get("app")
+        if app_mod and hasattr(app_mod, "get_sdr_device_status"):
+            if app_mod.get_sdr_device_status():
+                return True
+    except Exception:
+        pass
+    return _hackrf_probe_blocked()
 
 
 def _get_capabilities_for_type(sdr_type: SDRType) -> SDRCapabilities:
@@ -127,20 +142,33 @@ def detect_rtlsdr_devices() -> list[SDRDevice]:
             lib_paths = ["/usr/local/lib", "/opt/homebrew/lib"]
             current_ld = env.get("DYLD_LIBRARY_PATH", "")
             env["DYLD_LIBRARY_PATH"] = ":".join(lib_paths + [current_ld] if current_ld else lib_paths)
+        proc = subprocess.Popen(
+            [rtl_test_path, "-t"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+        )
         try:
-            result = subprocess.run(
-                [rtl_test_path, "-t"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=5,
-                env=env,
-            )
+            stdout, stderr = proc.communicate(timeout=5)
         except subprocess.TimeoutExpired:
-            logger.warning("rtl_test timed out after 5s")
-            return []
-        output = result.stderr + result.stdout
+            logger.warning("rtl_test timed out after 5s; stopping gracefully")
+            with contextlib.suppress(OSError):
+                proc.send_signal(signal.SIGINT)
+            try:
+                stdout, stderr = proc.communicate(timeout=1.5)
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(OSError):
+                    proc.terminate()
+                try:
+                    stdout, stderr = proc.communicate(timeout=0.5)
+                except subprocess.TimeoutExpired:
+                    with contextlib.suppress(OSError):
+                        proc.kill()
+                    stdout, stderr = proc.communicate()
+        output = (stderr or "") + (stdout or "")
 
         # Parse device info from rtl_test output
         # Format: "0:  Realtek, RTL2838UHIDIR, SN: 00000001"
@@ -257,7 +285,26 @@ def detect_soapy_devices(skip_types: set[SDRType] | None = None) -> list[SDRDevi
     try:
         # Use macOS-aware environment to find Homebrew-installed modules
         env = _get_soapy_env()
-        result = subprocess.run([soapy_cmd, "--find"], capture_output=True, text=True, timeout=10, env=env)
+        proc = subprocess.Popen(
+            [soapy_cmd, "--find"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        try:
+            stdout, _ = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            logger.warning("SoapySDRUtil timed out; terminating gracefully")
+            with contextlib.suppress(OSError):
+                proc.terminate()
+            try:
+                stdout, _ = proc.communicate(timeout=1.5)
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(OSError):
+                    proc.kill()
+                stdout, _ = proc.communicate()
+        output = stdout or ""
 
         # Parse SoapySDR output
         # Format varies but typically includes lines like:
@@ -268,7 +315,7 @@ def detect_soapy_devices(skip_types: set[SDRType] | None = None) -> list[SDRDevi
         current_device: dict = {}
         device_counts: dict[SDRType, int] = {}
 
-        for line in result.stdout.split("\n"):
+        for line in output.split("\n"):
             line = line.strip()
 
             # Start of new device block
@@ -289,8 +336,6 @@ def detect_soapy_devices(skip_types: set[SDRType] | None = None) -> list[SDRDevi
         if current_device.get("driver"):
             _add_soapy_device(devices, current_device, device_counts, skip_types)
 
-    except subprocess.TimeoutExpired:
-        logger.warning("SoapySDRUtil timed out")
     except Exception as e:
         logger.debug(f"SoapySDR detection error: {e}")
 
@@ -500,9 +545,21 @@ def probe_rtlsdr_device(device_index: int) -> str | None:
                 # rtl_test exited with error and we never saw a success message
                 error_found = True
         finally:
-            with contextlib.suppress(OSError):
-                proc.kill()
-            proc.wait()
+            if proc.poll() is None:
+                with contextlib.suppress(OSError):
+                    proc.send_signal(signal.SIGINT)
+                try:
+                    proc.wait(timeout=1.0)
+                except subprocess.TimeoutExpired:
+                    with contextlib.suppress(OSError):
+                        proc.terminate()
+                    try:
+                        proc.wait(timeout=0.5)
+                    except subprocess.TimeoutExpired:
+                        with contextlib.suppress(OSError):
+                            proc.kill()
+                        with contextlib.suppress(Exception):
+                            proc.wait(timeout=0.5)
             if device_found:
                 # Allow the kernel to fully release the USB interface
                 # before the caller opens the device with dump1090/rtl_fm/etc.
@@ -525,9 +582,9 @@ def detect_all_devices(force: bool = False) -> list[SDRDevice]:
     """
     Detect all connected SDR devices across all supported hardware types.
 
-    Results are cached for a few seconds so that multiple callers hitting
-    this within the same page-load cycle (e.g. /devices + /adsb/tools) do
-    not each spawn a full set of blocking subprocess probes.
+    Results are cached to avoid duplicate subprocess storms.
+    If an SDR is actively in use, cached results are returned to prevent
+    hardware contention and streaming disruptions.
 
     Args:
         force: Bypass the cache and re-probe hardware.
@@ -537,7 +594,15 @@ def detect_all_devices(force: bool = False) -> list[SDRDevice]:
     global _all_devices_cache, _all_devices_cache_ts
 
     now = time.time()
-    if not force and _all_devices_cache_ts and (now - _all_devices_cache_ts) < _ALL_DEVICES_CACHE_TTL_SECONDS:
+    cache_valid = bool(_all_devices_cache and (now - _all_devices_cache_ts) < _ALL_DEVICES_CACHE_TTL_SECONDS)
+
+    # When an SDR device is actively in use or streaming, avoid re-probing hardware
+    # which can cause USB bus contention and crash active captures.
+    if _all_devices_cache and (_is_sdr_in_use() or (not force and cache_valid)):
+        logger.debug("Returning cached device list (%d device(s))", len(_all_devices_cache))
+        return list(_all_devices_cache)
+
+    if not force and cache_valid:
         logger.debug("Returning cached device list (%d device(s))", len(_all_devices_cache))
         return list(_all_devices_cache)
 


### PR DESCRIPTION
### Summary of Problem

When stopping, switching modes, or probing SDR hardware (especially RTL-SDR and SoapySDR devices), the SDR hardware frequently locked up, aborted captures after a few seconds, or completely disappeared from the USB bus with `usb_claim_interface error -6` (Device or resource busy), `Failed to open ... error -110` (Connection timed out), or caused USB worker threads to stall.

Investigation revealed four interrelated root causes:

1. **Abrupt `SIGKILL` (`kill -9`) prevented clean release of USB endpoints**:
   - `utils/sdr/detection.py`: In `probe_rtlsdr_device()`, the `finally:` block unconditionally called `proc.kill()`. As soon as `Found 1 device(s)` was parsed, `proc.kill()` was invoked, sending `SIGKILL` directly to `rtl_test` while it had the USB interface open. This bypassed `librtlsdr` cleanup handlers (`libusb_release_interface` and `libusb_close`), leaving USB endpoints in a stalled state.
   - `routes/listening_post/__init__.py`: In `_stop_audio_stream_internal()`, process groups were immediately terminated with `os.killpg(..., signal.SIGKILL)`, abruptly killing `rtl_fm` without closing hardware handles.
   - `utils/process.py`: In `cleanup_stale_processes()`, `pkill -9` was used on `rtl_adsb`, `rtl_433`, `multimon-ng`, and `rtl_fm`.
   - `routes/listening_post/audio.py`: In `start_audio()` teardown, `pkill -9 rtl_power` was used.

2. **Timeout handling discarded detected devices and forced `SIGKILL`**:
   - `utils/sdr/detection.py`: `detect_rtlsdr_devices()` ran `subprocess.run(['rtl_test', '-t'], timeout=5)`. When `rtl_test -t` runs its tuner benchmark, it benchmarks indefinitely and hits the timeout. Python's `subprocess.run()` kills timed-out processes with `SIGKILL`, and the `except TimeoutExpired` block discarded all output and returned `[]`, despite the device list already having been printed to stderr.
   - `detect_soapy_devices()` had a similar timeout discard pattern.

3. **Background polling contention during active capture (`usb_claim_interface error -6`)**:
   - Web UI polling of `/devices/status` triggered `detect_all_devices()`, which had a short 5-second cache TTL (`_ALL_DEVICES_CACHE_TTL_SECONDS = 5.0`). When an SDR was actively in use (Sensors `rtl_433`, Meters `rtlamr`/`rtl_tcp`, ADS-B `dump1090`, or audio streaming), re-running `rtl_test` or `SoapySDRUtil --find` collided with the active stream over the shared USB interface, killing or aborting the active capture after a few seconds.

4. **Slow blocking probes during status polling**:
   - Polling `rtl_test -t` with a 5-second timeout blocked the web worker threads and introduced unnecessary latency when detecting devices.

---

### Solution

- **Graceful Process Termination**:
  - Replaced immediate `SIGKILL` in `routes/listening_post/__init__.py`, `utils/process.py`, and `routes/listening_post/audio.py` with `SIGTERM` / `SIGINT` first, allowing signal handlers in `rtl_fm`, `rtl_power`, and `dump1090` to execute `rtlsdr_close()` and release USB endpoints cleanly. Added a timeout fallback to `SIGKILL` only if the process fails to terminate.
  - In `probe_rtlsdr_device()`, replaced `proc.kill()` in `finally:` with `proc.send_signal(signal.SIGINT)` + `wait()`, ensuring the test probe releases the USB interface before the main decoder process attempts to claim it.

- **Fast & Resilient Device Detection**:
  - `rtl_test` outputs the complete device list immediately on startup (~50–100ms) before entering its indefinite tuner benchmark loop. In `detect_rtlsdr_devices()`, we now wait 0.3s for output, then send `SIGINT` to gracefully stop `rtl_test`. This drops RTL-SDR detection latency from 5+ seconds down to ~300ms without blocking or leaving zombie processes.
  - On timeout or exit, whatever device output was generated is retained and parsed instead of dropping devices.

- **Comprehensive Active Capture Protection & Cache Extension**:
  - Increased `_ALL_DEVICES_CACHE_TTL_SECONDS` from `5.0` to `30.0` to prevent probe storms from frontend polling.
  - Broadened `_is_sdr_in_use()` in `utils/sdr/detection.py` to inspect all active decoder processes (`sensor_process`, `current_process`, `adsb_process`, `rtlamr_process`, `ais_process`, `acars_process`, `vdl2_process`, `aprs_process`, `radiosonde_process`, `morse_process`), as well as `routes.rtlamr.rtl_tcp_process` and `routes.listening_post.audio_running`.
  - When an SDR is actively in use by any mode, physical USB bus re-probing is completely bypassed and cached device info is returned, eliminating USB contention crashes.

- **Test Suite**:
  - Updated `tests/test_sdr_detection.py` to test `Popen` and added test coverage for graceful timeout recovery.
  - All 8 unit tests pass (`pytest tests/test_sdr_detection.py`).

---

### Hardware & Virtualization Notes

Tested on live Linux hardware and Proxmox QEMU virtual machine pass-through environments:
- RTL-SDR (RTL2838UHIDIR with Elonics E4000 tuner)
- RTL-SDR Blog V3/V4 (R820T2)
- LimeSDR (LimeSDR Mini v2.2)

**Operational Note for Virtualized / VM Passthrough Deployments**:
When passing through an RTL-SDR to a virtual machine (e.g. Proxmox, QEMU, ESXi), ensure the virtual USB controller is configured for USB 2.0/3.0 High-Speed (480 Mbps, e.g. `qm set <vmid> -usb0 mapping=<name>,usb3=1` or `qemu-xhci`). Legacy USB 1.1 UHCI controllers cap throughput at 12 Mbps. Because an RTL-SDR sampling at 2 MSps generates ~32 Mbps raw I/Q samples, USB 1.1 controllers will buffer overflow within 2–3 seconds, causing capture tools (`rtl_433`, `rtlamr`, `rtl_fm`) to abruptly fail. With USB 3.0 / xHCI passthrough and the fixes in this PR, streams run continuously and indefinitely without drops.
